### PR TITLE
Break points and cleaded main.cpp

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,13 +8,13 @@ insert_final_newline = true
 charset = utf-8
 
 # 4 space indentation
-[*.{cpp,hpp,c,h}]
+[*.{cpp,hpp,c,h,in,inc,asm}]
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 
-# Matches the exact files either package.json or .travis.yml
-[{package.json,.travis.yml}]
+# Matches .travis.yml
+[{.travis.yml}]
 indent_style = space
 indent_size = 2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,146 +1,144 @@
 cmake_minimum_required(VERSION 2.6)
 
-if (VCOMPUTER_SUB_PROJECT)
-	message (STATUS "Setting SRC and INCLUDE for Trillek VCOMPUTER")
+project(VCOMPUTER)
 
-	# Include dirs
-	set(VCOMPUTER_INCLUDE_DIRS
-		"${CMAKE_CURRENT_SOURCE_DIR}/include/"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/TR3200"
-		"${CMAKE_CURRENT_SOURCE_DIR}/include/devices"
-		PARENT_SCOPE
-		)
+# Project generic variables
+set(VCOMP_VERSION_MAJOR 0)
+set(VCOMP_VERSION_MINOR 2)
 
-	# Source dirs
-	file(GLOB VCOMPUTER_SRC_
-		"${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/TR3200/*.cpp"
-		"${CMAKE_CURRENT_SOURCE_DIR}/src/devices/*.cpp"
-		)
+# Debug build ?
+IF (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  message("Debug build")
+  set(DEBUG_BUILD 1)
 
-	set(VCOMPUTER_SRC
-		${VCOMPUTER_SRC_}
-		PARENT_SCOPE
-		)
+else (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(DEBUG_BUILD 0)
 
-else (VCOMPUTER_SUB_PROJECT)
+endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
 
-	project(VCOMPUTER)
+# Options for optional compiling stuff
+set(BUILD_TOOLS_VCOMPUTER TRUE CACHE BOOL "Build Trillek VCOMPUTER tools")
+set(BUILD_TESTS_VCOMPUTER TRUE CACHE BOOL "Build Trillek VCOMPUTER tests")
+set(BUILD_STATIC_VCOMPUTER FALSE CACHE BOOL "Build Trillek VCOMPUTER as a static library")
 
-	# We like having options
-	set(BUILD_TOOLS_VCOMPUTER TRUE CACHE BOOL "Build Trillek VCOMPUTER tools")
-	set(BUILD_TESTS_VCOMPUTER TRUE CACHE BOOL "Build Trillek VCOMPUTER tests")
-	set(BUILD_STATIC_VCOMPUTER FALSE CACHE BOOL "Build Trillek VCOMPUTER as a static library")
+# Optiones that affect functionality
+set(BRKPOINTS_ENABLED 1 CACHE INT "Enables Break Points functionality")
 
-	# Set the directory where to find FindSLD2.cmake
-	set(CMAKE_MODULE_PATH ${VCOMPUTER_SOURCE_DIR}/cmake)
+IF (BRKPOINTS_ENABLED)
+  message("Breakpoints functionality enabled")
+ENDIF (BRKPOINTS_ENABLED)
 
-	set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+# Set the directory where to find FindSLD2.cmake
+set(CMAKE_MODULE_PATH ${VCOMPUTER_SOURCE_DIR}/cmake)
 
-	# Include dirs
-	set(VCOMPUTER_INCLUDE_DIRS
-		${PROJECT_BINARY_DIR}
-		${VCOMPUTER_SOURCE_DIR}/include
-    ${VCOMPUTER_SOURCE_DIR}/include/TR3200
-		${VCOMPUTER_SOURCE_DIR}/include/devices
-		)
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-	# Source dirs
-	file(GLOB VCOMPUTER_SRC
-		"src/*.cpp"
-    "src/TR3200/*.cpp"
-		"src/devices/*.cpp"
-		"include/*.hpp"
-    "include/TR3200/*.hpp"
-		"include/devices/*.hpp"
-		)
+# Include dirs
+set(VCOMPUTER_INCLUDE_DIRS
+  ${PROJECT_BINARY_DIR}
+  ${VCOMPUTER_SOURCE_DIR}/include
+  ${VCOMPUTER_SOURCE_DIR}/include/TR3200
+  ${VCOMPUTER_SOURCE_DIR}/include/devices
+  )
 
+# Source dirs
+file(GLOB VCOMPUTER_SRC
+  "src/*.cpp"
+  "src/TR3200/*.cpp"
+  "src/devices/*.cpp"
+  "include/*.hpp"
+  "include/TR3200/*.hpp"
+  "include/devices/*.hpp"
+  )
 
-	if (EMSCRIPTEN)
-		# We are compiling with emscripten
+# Apply all configuration stuff to Config.hpp.in
+configure_file (src/Config.hpp.in
+  "${PROJECT_BINARY_DIR}/Config.hpp" )
 
-		set(CMAKE_CXX_FLAGS "-std=c++11 ${MAKE_CXX_FLAGS}")
-		set(CMAKE_EXECUTABLE_SUFFIX ".js")
+if (EMSCRIPTEN)
+  # We are compiling with emscripten
 
-		message(STATUS "Procesing Source Code - Build Library JS Wrapper")
-		add_subdirectory(emscripten)
+  set(CMAKE_CXX_FLAGS "-std=c++11 ${MAKE_CXX_FLAGS}")
+  set(CMAKE_EXECUTABLE_SUFFIX ".js")
 
-	else (EMSCRIPTEN)
+  message(STATUS "Procesing Source Code - Build Library JS Wrapper")
+  add_subdirectory(emscripten)
 
-		include(Platform)
+else (EMSCRIPTEN)
 
-		message(STATUS "Procesing Source Code - Build library")
-		# VCOMPUTER VM core lib
-		if(BUILD_STATIC_VCOMPUTER)
-			add_library( VCOMPUTER STATIC
-				${VCOMPUTER_SRC}
-				)
+  include(Platform)
 
-			include_directories(VCOMPUTER
-				${VCOMPUTER_INCLUDE_DIRS}
-				)
+  message(STATUS "Procesing Source Code - Build library")
+  # VCOMPUTER VM core lib
+  if(BUILD_STATIC_VCOMPUTER)
+    add_library( VCOMPUTER STATIC
+      ${VCOMPUTER_SRC}
+      )
 
-		else(BUILD_STATIC_VCOMPUTER)
-			add_library( VCOMPUTER SHARED
-				${VCOMPUTER_SRC}
-				)
+    include_directories(VCOMPUTER
+      ${VCOMPUTER_INCLUDE_DIRS}
+      )
 
-			include_directories(VCOMPUTER
-				${VCOMPUTER_INCLUDE_DIRS}
-				)
+  else(BUILD_STATIC_VCOMPUTER)
+    add_library( VCOMPUTER SHARED
+      ${VCOMPUTER_SRC}
+      )
 
-		endif(BUILD_STATIC_VCOMPUTER)
+    include_directories(VCOMPUTER
+      ${VCOMPUTER_INCLUDE_DIRS}
+      )
 
-		if(BUILD_TOOLS_VCOMPUTER OR BUILD_TESTS_VCOMPUTER)
+  endif(BUILD_STATIC_VCOMPUTER)
 
-			# Find GLFW3 and OpenGL libs
-			find_package(GLFW3)
-			if (NOT GLFW3_FOUND)
-				message("GLFW3 not found! main executable will not display screen and virtual keyboard")
-				set (GLFW3_ENABLE 0)
-			else (NOT GLFW3_FOUND)
-				set (GLFW3_ENABLE 1)
-			endif (NOT GLFW3_FOUND)
+  if(BUILD_TOOLS_VCOMPUTER OR BUILD_TESTS_VCOMPUTER)
 
-			find_package(OpenGL)
-			if (NOT OPENGL_FOUND)
-				message("OpenGL not found! main executable will not display screen and virtual keyboard")
-				set (GLFW3_ENABLE 0)
-			endif (NOT OPENGL_FOUND)
+    # Find GLFW3 and OpenGL libs
+    find_package(GLFW3)
+    if (NOT GLFW3_FOUND)
+      message("GLFW3 not found! main executable will not display screen and virtual keyboard")
+      set (GLFW3_ENABLE 0)
+    else (NOT GLFW3_FOUND)
+      set (GLFW3_ENABLE 1)
+    endif (NOT GLFW3_FOUND)
 
-			find_package(GLEW)
-			if(NOT GLEW_FOUND)
-				message("GLEW not found! main executable will not display screen and virtual keyboard")
-				set (GLFW3_ENABLE 0)
-			endif(NOT GLEW_FOUND)
+    find_package(OpenGL)
+    if (NOT OPENGL_FOUND)
+      message("OpenGL not found! main executable will not display screen and virtual keyboard")
+      set (GLFW3_ENABLE 0)
+    endif (NOT OPENGL_FOUND)
 
-			find_package(GLM)
-			if(NOT GLM_FOUND)
-				message("GLM not found! main executable will not display screen and virtual keyboard")
-				set (GLFW3_ENABLE 0)
-			endif(NOT GLM_FOUND)
+    find_package(GLEW)
+    if(NOT GLEW_FOUND)
+      message("GLEW not found! main executable will not display screen and virtual keyboard")
+      set (GLFW3_ENABLE 0)
+    endif(NOT GLEW_FOUND)
 
-			if(BUILD_TOOLS_VCOMPUTER)
-				message(STATUS "Procesing Tools")
-				add_subdirectory(tools)
-			endif(BUILD_TOOLS_VCOMPUTER)
+    find_package(GLM)
+    if(NOT GLM_FOUND)
+      message("GLM not found! main executable will not display screen and virtual keyboard")
+      set (GLFW3_ENABLE 0)
+    endif(NOT GLM_FOUND)
 
-			message(STATUS "Procesing Assets")
-			add_subdirectory(assets)
+    if(BUILD_TOOLS_VCOMPUTER)
+      message(STATUS "Procesing Tools")
+      add_subdirectory(tools)
+    endif(BUILD_TOOLS_VCOMPUTER)
 
-		endif(BUILD_TOOLS_VCOMPUTER OR BUILD_TESTS_VCOMPUTER)
+    message(STATUS "Procesing Assets")
+    add_subdirectory(assets)
 
-		if(BUILD_TESTS_VCOMPUTER)
-			message(STATUS "Procesing Tests")
+  endif(BUILD_TOOLS_VCOMPUTER OR BUILD_TESTS_VCOMPUTER)
 
-			if(DEFINED ENV{GTEST_ROOT})  # Note we omit the $ here!
-			  add_subdirectory($ENV{GTEST_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/gtest)
-			endif()
+  if(BUILD_TESTS_VCOMPUTER)
+    message(STATUS "Procesing Tests")
 
-			add_subdirectory(tests)
-		endif(BUILD_TESTS_VCOMPUTER)
+    if(DEFINED ENV{GTEST_ROOT})  # Note we omit the $ here!
+      add_subdirectory($ENV{GTEST_ROOT} ${CMAKE_CURRENT_BINARY_DIR}/gtest)
+    endif()
 
-	endif (EMSCRIPTEN)
+    add_subdirectory(tests)
+  endif(BUILD_TESTS_VCOMPUTER)
 
-endif (VCOMPUTER_SUB_PROJECT)
+endif (EMSCRIPTEN)
+
 

--- a/include/VComputer.hpp
+++ b/include/VComputer.hpp
@@ -327,9 +327,16 @@ namespace vm {
          */
         bool isBreakPoint (dword_t addr) {
             if (breakpoints.find(addr) != breakpoints.end() ) {
+                last_break = addr;
                 breaking = true;
                 return true;
             }
+
+            if (recover_break) { // Recover temporaly removed breakpoint
+                SetBreakPoint(last_break);
+                recover_break = false;
+            }
+
             return false;
         }
 
@@ -337,7 +344,7 @@ namespace vm {
          * Check if the Virtual Computer is halted by a breakpoint
          * \return True if a breakpoint happened
          */
-        bool isBreraked () {
+        bool isBreaked () {
             return breaking;
         }
 
@@ -346,6 +353,10 @@ namespace vm {
          */
         void Continue () {
             breaking = false;
+
+            // Temporaly, we remove the last break point
+            RmBreakPoint(last_break);
+            recover_break = true;
         }
 
     private:
@@ -368,8 +379,11 @@ namespace vm {
         RTC rtc;                //! Real Time Clock
 
 
-        std::set<dword_t> breakpoints; //! Breakpoints list
-        bool breaking;
+        std::set<dword_t> breakpoints;  //! Breakpoints list
+        bool breaking;                  //! The Virtual Computer is halted in a BreakPoint ?
+
+        dword_t last_break; //! Address tof the last breakpoint finded
+        bool recover_break; //! Flag to know if a recovered the temporaly erases break
     };
 
 

--- a/include/VComputer.hpp
+++ b/include/VComputer.hpp
@@ -344,19 +344,20 @@ namespace vm {
          * Check if the Virtual Computer is halted by a breakpoint
          * \return True if a breakpoint happened
          */
-        bool isBreaked () {
+        bool isHalted () {
             return breaking;
         }
 
         /*!
          * Allows to continue if a Breakpoint happened
          */
-        void Continue () {
-            breaking = false;
-
-            // Temporaly, we remove the last break point
-            RmBreakPoint(last_break);
-            recover_break = true;
+        void Resume () {
+            if (breaking) {
+                breaking = false;
+                // Temporaly, we remove the last break point
+                RmBreakPoint(last_break);
+                recover_break = true;
+            }
         }
 
     private:

--- a/include/VComputer.hpp
+++ b/include/VComputer.hpp
@@ -18,6 +18,7 @@
 #include "RTC.hpp"
 
 #include <map>
+#include <set>
 #include <memory>
 #include <cassert>
 
@@ -275,7 +276,7 @@ namespace vm {
         /*!
          * Sizeo of the RAM in bytes
          */
-        std::size_t RamSize() const {
+        std::size_t RamSize () const {
             return ram_size;
         }
 
@@ -283,7 +284,7 @@ namespace vm {
          * Returns a pointer to the RAM for reading raw values from it
          * Use only for GetState methods or dump a snapshot of the computer state
          */
-        const byte_t* Ram() const {
+        const byte_t* Ram () const {
             return ram;
         }
 
@@ -293,6 +294,58 @@ namespace vm {
          */
         byte_t* Ram() {
             return ram;
+        }
+
+
+        /*!
+         * Add a breakpoint at the desired address
+         * \param addr Address were will be the breakpoint
+         */
+        void SetBreakPoint (dword_t addr) {
+            breakpoints.insert(addr);
+        }
+
+        /*!
+         * Erase a breakpoint at the desired address
+         * \param addr Address were will be the breakpoint
+         */
+        void RmBreakPoint (dword_t addr) {
+            breakpoints.erase(addr);
+        }
+
+        /*!
+         * Remove all breakpoints
+         */
+        void ClearBreakPoints () {
+            breakpoints.clear();
+        }
+
+        /*!
+         * Check if there isa breakpoint at an particular address
+         * \param addr Address to verify
+         * \return True if there is a breakpoint in these address
+         */
+        bool isBreakPoint (dword_t addr) {
+            if (breakpoints.find(addr) != breakpoints.end() ) {
+                breaking = true;
+                return true;
+            }
+            return false;
+        }
+
+        /*!
+         * Check if the Virtual Computer is halted by a breakpoint
+         * \return True if a breakpoint happened
+         */
+        bool isBreraked () {
+            return breaking;
+        }
+
+        /*!
+         * Allows to continue if a Breakpoint happened
+         */
+        void Continue () {
+            breaking = false;
         }
 
     private:
@@ -313,6 +366,10 @@ namespace vm {
         Timer pit;              //! Programable Interval Timer
         RNG rng;                //! Random Number Generator
         RTC rtc;                //! Real Time Clock
+
+
+        std::set<dword_t> breakpoints; //! Breakpoints list
+        bool breaking;
     };
 
 

--- a/include/VComputer.hpp
+++ b/include/VComputer.hpp
@@ -1,6 +1,9 @@
 #pragma once
-/**
- * Trillek Virtual Computer - VComputer.hpp
+/*!
+ * \brief       Virtual Computer Core
+ * \file        VComputer.hpp
+ * \copyright   The MIT License (MIT)
+ *
  * Virtual Computer core
  */
 
@@ -19,314 +22,298 @@
 #include <cassert>
 
 namespace vm {
-  using namespace vm::cpu;
+    using namespace vm::cpu;
 
-  const unsigned MAX_N_DEVICES    = 32;         /// Max number of devices attached
-  const std::size_t MAX_ROM_SIZE  = 32*1024;    /// Max ROM size
-  const std::size_t MAX_RAM_SIZE  = 1024*1024;  /// Max RAM size
+    const unsigned MAX_N_DEVICES    = 32;         //! Max number of devices attached
+    const std::size_t MAX_ROM_SIZE  = 32*1024;    //! Max ROM size
+    const std::size_t MAX_RAM_SIZE  = 1024*1024;  //! Max RAM size
 
-  const unsigned EnumCtrlBlkSize  = 20;         /// Enumeration and Control registers blk size
+    const unsigned EnumCtrlBlkSize  = 20;         //! Enumeration and Control registers blk size
 
-  const unsigned BaseClock  = 1000000;          /// Computer Base Clock rate
+    const unsigned BaseClock  = 1000000;          //! Computer Base Clock rate
 
-  class EnumAndCtrlBlk;
+    class EnumAndCtrlBlk;
 
-  class VComputer {
+    class VComputer {
     public:
 
-      /**
-       * Creates a Virtual Computer
-       * @param ram_size RAM size in BYTES
-       */
-      VComputer (std::size_t ram_size = 128*1024);
+        /*!
+         * Creates a Virtual Computer
+         * \param ram_size RAM size in BYTES
+         */
+        VComputer (std::size_t ram_size = 128*1024);
 
-      ~VComputer ();
+        ~VComputer ();
 
-      /**
-       * Sets the CPU of the computer
-       * @param cpu New CPU in the computer
-       */
-      void SetCPU (std::unique_ptr<ICPU> cpu);
+        /*!
+         * Sets the CPU of the computer
+         * \param cpu New CPU in the computer
+         */
+        void SetCPU (std::unique_ptr<ICPU> cpu);
 
-      /**
-       * Removes the CPU of the computer
-       * @return Returns the ICPU
-       */
-      std::unique_ptr<ICPU> RmCPU ();
+        /*!
+         * Removes the CPU of the computer
+         * \return Returns the ICPU
+         */
+        std::unique_ptr<ICPU> RmCPU ();
 
-      /**
-       * Adds a Device to a slot
-       * @param slot Were plug the device
-       * @param dev The device to be pluged in the slot
-       * @return False if the slot have a device or the slot is invalid.
-       */
-      bool AddDevice (unsigned slot , std::shared_ptr<IDevice> dev);
+        /*!
+         * Adds a Device to a slot
+         * \param slot Were plug the device
+         * \param dev The device to be pluged in the slot
+         * \return False if the slot have a device or the slot is invalid.
+         */
+        bool AddDevice (unsigned slot , std::shared_ptr<IDevice> dev);
 
-      /**
-       * Gets the Device plugged in the slot
-       */
-      std::shared_ptr<IDevice> GetDevice (unsigned slot);
+        /*!
+         * Gets the Device plugged in the slot
+         */
+        std::shared_ptr<IDevice> GetDevice (unsigned slot);
 
-      /**
-       * Remove a device from a slot
-       * @param slot Slot were unplug the device
-       */
-      void RmDevice (unsigned slot);
+        /*!
+         * Remove a device from a slot
+         * \param slot Slot were unplug the device
+         */
+        void RmDevice (unsigned slot);
 
-      /**
-       * CPU clock speed in Hz
-       */
-      unsigned CPUClock() const;
+        /*!
+         * CPU clock speed in Hz
+         */
+        unsigned CPUClock() const;
 
-      /**
-       * Writes a copy of CPU state in a chunk of memory pointer by ptr.
-       * @param ptr Pointer were to write
-       * @param size Size of the chunk of memory were can write. If is
-       * sucesfull, it will be set to the size of the write data.
-       */
-      void GetState (void* ptr, std::size_t size) const;
+        /*!
+         * Writes a copy of CPU state in a chunk of memory pointer by ptr.
+         * \param ptr Pointer were to write
+         * \param size Size of the chunk of memory were can write. If is
+         * sucesfull, it will be set to the size of the write data.
+         */
+        void GetState (void* ptr, std::size_t size) const;
 
-      /**
-       * Gets a pointer were is stored the ROM data
-       * @param *rom Ptr to the ROM data
-       * @param rom_size Size of the ROM data that must be less or equal to 32KiB. Big sizes will be ignored
-       */
-      void SetROM (const byte_t* rom, std::size_t rom_size);
+        /*!
+         * Gets a pointer were is stored the ROM data
+         * \param *rom Ptr to the ROM data
+         * \param rom_size Size of the ROM data that must be less or equal to 32KiB. Big sizes will be ignored
+         */
+        void SetROM (const byte_t* rom, std::size_t rom_size);
 
-      /**
-       * Resets the virtual machine (but not clears RAM!)
-       */
-      void Reset();
+        /*!
+         * Resets the virtual machine (but not clears RAM!)
+         */
+        void Reset();
 
-      /**
-       * Executes one instruction
-       * @param delta Number of seconds since the last call
-       * @return number of base clock ticks needed
-       */
-      unsigned Step( const double delta = 0);
+        /*!
+         * Power On the computer
+         */
+        void On();
 
-      /**
-       * Executes N clock ticks
-       * @param n nubmer of base clock ticks, by default 1
-       * @param delta Number of seconds since the last call
-       */
-      void Tick( unsigned n=1, const double delta = 0) {
-        assert(n >0);
-        unsigned dev_ticks = n / 10; // Devices clock is at 100 KHz
-        if (cpu) {
-          unsigned cpu_ticks = n / (BaseClock / cpu->Clock());
+        /*!
+         * Power Off the computer
+         */
+        void Off();
 
-          cpu->Tick(cpu_ticks);
-          pit.Tick(dev_ticks, delta);
+        /*!
+         * Executes the apropaited number of Virtual Computer base clock cycles
+         * in function of the elapsed time since the last call (delta time)
+         *
+         * \param delta Number of seconds since the last call
+         * \return Number of base clock cycles executed
+         */
+        unsigned Update( const double delta);
 
-          word_t msg;
-          bool interrupted = pit.DoesInterrupt(msg); // Highest priority interrupt
-          if (interrupted) {
-            if (cpu->SendInterrupt(msg)) { // Send the interrupt to the CPU
-              pit.IACK();
+        /*!
+         * Executes one instruction
+         * \param delta Number of seconds since the last call
+         * \return number of base clock ticks needed
+         */
+        unsigned Step( const double delta = 0);
+
+        /*!
+         * Executes N clock ticks
+         * \param n nubmer of base clock ticks, by default 1
+         * \param delta Number of seconds since the last call
+         */
+        void Tick( unsigned n=1, const double delta = 0);
+
+        byte_t ReadB (dword_t addr) const {
+            addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
+
+            if (!(addr & 0xF00000 )) { // RAM address (0x000000-0x0FFFFF)
+                return ram[addr];
             }
-          }
 
-          for (std::size_t i=0; i < MAX_N_DEVICES; i++) {
-            if (! std::get<0>(devices[i])) {
-              continue; // Slot without device
+            if ((addr & 0xFF0000) == 0x100000 ) { // ROM (0x100000-0x10FFFF)
+                return rom[addr & 0x00FFFF];
             }
 
-            // Does the sync job
-            if ( std::get<0>(devices[i])->IsSyncDev()) {
-              std::get<0>(devices[i])->Tick(dev_ticks, delta);
+            Range r(addr);
+            auto search = listeners.find(r);
+            if (search != listeners.end()) {
+                return search->second->ReadB(addr);
             }
 
-            // Try to get the highest priority interrupt
-            if (! interrupted && std::get<0>(devices[i])->DoesInterrupt(msg) ) {
-              interrupted = true;
-              if (cpu->SendInterrupt(msg)) { // Send the interrupt to the CPU
-                std::get<0>(devices[i])->IACK(); // Informs to the device that his interrupt has been accepted by the CPU
-              }
+            return 0;
+        }
+
+        word_t ReadW (dword_t addr) const {
+            addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
+            size_t tmp;
+
+            if (!(addr & 0xF00000 )) { // RAM address
+                tmp = ((size_t)ram) + addr;
+                return ((word_t*)tmp)[0];
             }
-          }
 
-        }
-      }
+            if ((addr & 0xFF0000) == 0x100000 ) { // ROM (0x100000-0x10FFFF)
+                addr &= 0x00FFFF; // Dirty tricks with pointers
+                tmp = ((size_t)rom) + addr;
+                return ((word_t*)tmp)[0];
+            }
 
-      byte_t ReadB (dword_t addr) const {
-        addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
+            Range r(addr);
+            auto search = listeners.find(r);
+            if (search != listeners.end()) {
+                return search->second->ReadW(addr);
+            }
 
-        if (!(addr & 0xF00000 )) { // RAM address (0x000000-0x0FFFFF)
-          return ram[addr];
-        }
-
-        if ((addr & 0xFF0000) == 0x100000 ) { // ROM (0x100000-0x10FFFF)
-          return rom[addr & 0x00FFFF];
-        }
-
-        Range r(addr);
-        auto search = listeners.find(r);
-        if (search != listeners.end()) {
-          return search->second->ReadB(addr);
+            return 0;
         }
 
-        return 0;
-      }
+        dword_t ReadDW (dword_t addr) const {
+            addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
+            size_t tmp;
 
-      word_t ReadW (dword_t addr) const {
-        addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
-        size_t tmp;
+            if (!(addr & 0xF00000 )) { // RAM address
+                tmp = ((size_t)ram) + addr;
+                return ((dword_t*)tmp)[0];
+            }
 
-        if (!(addr & 0xF00000 )) { // RAM address
-          tmp = ((size_t)ram) + addr;
-          return ((word_t*)tmp)[0];
+            if ((addr & 0xFF0000) == 0x100000 ) { // ROM (0x100000-0x10FFFF)
+                addr &= 0x00FFFF; // Dirty tricks with pointers
+                tmp = ((size_t)rom) + addr;
+                return ((dword_t*)tmp)[0];
+            }
+
+            Range r(addr);
+            auto search = listeners.find(r);
+            if (search != listeners.end()) {
+                return search->second->ReadDW(addr);
+            }
+
+            return 0;
         }
 
-        if ((addr & 0xFF0000) == 0x100000 ) { // ROM (0x100000-0x10FFFF)
-          addr &= 0x00FFFF; // Dirty tricks with pointers
-          tmp = ((size_t)rom) + addr;
-          return ((word_t*)tmp)[0];
+        void WriteB (dword_t addr, byte_t val) {
+            addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
+
+            if (addr < ram_size) { // RAM address
+                ram[addr] = val;
+            }
+
+            Range r(addr);
+            auto search = listeners.find(r);
+            if (search != listeners.end()) {
+                search->second->WriteB(addr, val);
+            }
+
         }
 
-        Range r(addr);
-        auto search = listeners.find(r);
-        if (search != listeners.end()) {
-          return search->second->ReadW(addr);
+        void WriteW (dword_t addr, word_t val) {
+            size_t tmp;
+            addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
+
+            if (addr < ram_size-1 ) { // RAM address
+                tmp = ((size_t)ram) + addr;
+                ((word_t*)tmp)[0] = val;
+            }
+            // TODO What hapens when there is a write that falls half in RAM and
+            // half outside ?
+            // I actually forbid these cases to avoid buffer overun, but should be
+            // allowed and only use the apropiate portion of the data in the RAM.
+
+            Range r(addr);
+            auto search = listeners.find(r);
+            if (search != listeners.end()) {
+                search->second->WriteW(addr, val);
+            }
+
         }
 
-        return 0;
-      }
+        void WriteDW (dword_t addr, dword_t val) {
+            size_t tmp;
+            addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
 
-      dword_t ReadDW (dword_t addr) const {
-        addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
-        size_t tmp;
+            if (addr < ram_size-3 ) { // RAM address
+                tmp = ((size_t)ram) + addr;
+                ((dword_t*)tmp)[0] = val;
+            }
+            // TODO What hapens when there is a write that falls half in RAM and
+            // half outside ?
 
-        if (!(addr & 0xF00000 )) { // RAM address
-          tmp = ((size_t)ram) + addr;
-          return ((dword_t*)tmp)[0];
+            Range r(addr);
+            auto search = listeners.find(r);
+            if (search != listeners.end()) {
+                search->second->WriteDW(addr, val);
+            }
+
         }
 
-        if ((addr & 0xFF0000) == 0x100000 ) { // ROM (0x100000-0x10FFFF)
-          addr &= 0x00FFFF; // Dirty tricks with pointers
-          tmp = ((size_t)rom) + addr;
-          return ((dword_t*)tmp)[0];
+        /*!
+         * Adds an AddrListener to the computer
+         * \param range Range of addresses that the listerner listens
+         * \param listener AddrListener using these range
+         * \return And ID oif the listener or -1 if can't add the listener
+         */
+        int32_t AddAddrListener (const Range& range, AddrListener* listener);
+
+        /*!
+         * Removes an AddrListener from the computer
+         * \param id ID of the address listener to remove (ID from AddAddrListener)
+         * \return True if can find these listener and remove it.
+         */
+        bool RmAddrListener (int32_t id);
+
+        /*!
+         * Sizeo of the RAM in bytes
+         */
+        std::size_t RamSize() const {
+            return ram_size;
         }
 
-        Range r(addr);
-        auto search = listeners.find(r);
-        if (search != listeners.end()) {
-          return search->second->ReadDW(addr);
+        /*!
+         * Returns a pointer to the RAM for reading raw values from it
+         * Use only for GetState methods or dump a snapshot of the computer state
+         */
+        const byte_t* Ram() const {
+            return ram;
         }
 
-        return 0;
-      }
-
-      void WriteB (dword_t addr, byte_t val) {
-        addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
-
-        if (addr < ram_size) { // RAM address
-          ram[addr] = val;
+        /*!
+         * Returns a pointer to the RAM for writing raw values to it
+         * Use only for SetState methods or load a snapshot of the computer state
+         */
+        byte_t* Ram() {
+            return ram;
         }
-
-        Range r(addr);
-        auto search = listeners.find(r);
-        if (search != listeners.end()) {
-          search->second->WriteB(addr, val);
-        }
-
-      }
-
-      void WriteW (dword_t addr, word_t val) {
-        size_t tmp;
-        addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
-
-        if (addr < ram_size-1 ) { // RAM address
-          tmp = ((size_t)ram) + addr;
-          ((word_t*)tmp)[0] = val;
-        }
-        // TODO What hapens when there is a write that falls half in RAM and
-        // half outside ?
-        // I actually forbid these cases to avoid buffer overun, but should be
-        // allowed and only use the apropiate portion of the data in the RAM.
-
-        Range r(addr);
-        auto search = listeners.find(r);
-        if (search != listeners.end()) {
-          search->second->WriteW(addr, val);
-        }
-
-      }
-
-      void WriteDW (dword_t addr, dword_t val) {
-        size_t tmp;
-        addr = addr & 0x00FFFFFF; // We use only 24 bit addresses
-
-        if (addr < ram_size-3 ) { // RAM address
-          tmp = ((size_t)ram) + addr;
-          ((dword_t*)tmp)[0] = val;
-        }
-        // TODO What hapens when there is a write that falls half in RAM and
-        // half outside ?
-
-        Range r(addr);
-        auto search = listeners.find(r);
-        if (search != listeners.end()) {
-          search->second->WriteDW(addr, val);
-        }
-
-      }
-
-      /**
-       * Adds an AddrListener to the computer
-       * @param range Range of addresses that the listerner listens
-       * @param listener AddrListener using these range
-       * @return And ID oif the listener or -1 if can't add the listener
-       */
-      int32_t AddAddrListener (const Range& range, AddrListener* listener);
-
-      /**
-       * Removes an AddrListener from the computer
-       * @param id ID of the address listener to remove (ID from AddAddrListener)
-       * @return True if can find these listener and remove it.
-       */
-      bool RmAddrListener (int32_t id);
-
-      /**
-       * Sizeo of the RAM in bytes
-       */
-      std::size_t RamSize() const {
-        return ram_size;
-      }
-
-      /**
-       * Returns a pointer to the RAM for reading raw values from it
-       * Use only for GetState methods or dump a snapshot of the computer state
-       */
-      const byte_t* Ram() const {
-        return ram;
-      }
-
-      /**
-       * Returns a pointer to the RAM for writing raw values to it
-       * Use only for SetState methods or load a snapshot of the computer state
-       */
-      byte_t* Ram() {
-        return ram;
-      }
 
     private:
 
-      byte_t* ram;            /// Computer RAM
-      const byte_t* rom;      /// Computer ROM chip (could be shared between some VComputers)
-      std::size_t ram_size;   /// Computer RAM size
-      std::size_t rom_size;   /// Computer ROM size
+        bool is_on;             //! Is PowerOn the computer ?
 
-      std::unique_ptr<ICPU> cpu;                /// Virtual CPU
+        byte_t* ram;            //! Computer RAM
+        const byte_t* rom;      //! Computer ROM chip (could be shared between some VComputers)
+        std::size_t ram_size;   //! Computer RAM size
+        std::size_t rom_size;   //! Computer ROM size
 
-      device_t devices[MAX_N_DEVICES];          /// Devices atached to the virtual computer
+        std::unique_ptr<ICPU> cpu;                //! Virtual CPU
 
-      std::map<Range, AddrListener*> listeners; /// Container of AddrListeners
+        device_t devices[MAX_N_DEVICES];          //! Devices atached to the virtual computer
 
-      Timer pit;  /// Programable Interval Timer
-      RNG rng; /// Random Number Generator
-      RTC rtc; /// Real Time Clock
-  };
+        std::map<Range, AddrListener*> listeners; //! Container of AddrListeners
+
+        Timer pit;              //! Programable Interval Timer
+        RNG rng;                //! Random Number Generator
+        RTC rtc;                //! Real Time Clock
+    };
 
 
 } // End of namespace vm

--- a/src/Config.hpp.in
+++ b/src/Config.hpp.in
@@ -1,0 +1,28 @@
+#pragma once
+/*!
+ * \brief       Virtual Computer confgiration file
+ * \file        Config.hpp.in
+ * \copyright   The MIT License (MIT)
+ *
+ * This file is procesed by CMake to setup the apropiated macros of configuration
+ */
+
+#define VCOMP_VERSION_MAJOR @VCOMP_VERSION_MAJOR@   //! Major version
+#define VCOMP_VERSION_MINOR @VCOMP_VERSION_MINOR@   //! Minor version
+#define VCOMP_BUILD @VCOMP_BUILD@                   //! Build (git rev-list HEAD --count)
+
+//! Debug build
+#ifndef DEBUG
+    #define DEBUG @DEBUG_BUILD@
+#endif
+#if DEBUG == 0
+    #undef DEBUG
+#endif
+
+
+//! Break Points functionality ?
+#define BRKPOINTS @BRKPOINTS_ENABLED@
+#if BRKPOINTS == 0
+    #undef BRKPOINTS
+#endif
+

--- a/src/TR3200/DisTR3200.cpp
+++ b/src/TR3200/DisTR3200.cpp
@@ -27,7 +27,6 @@ namespace vm {
       // Here beging the Decoding
       bool literal = HAVE_LITERAL(inst);
       opcode = GET_OP_CODE(inst);
-      std::fprintf(stderr,"OP 0x%02x\t", opcode);
 
       if (IS_P3(inst)) {
         // 3 parameter instruction ********************************************

--- a/src/TR3200/TR3200.cpp
+++ b/src/TR3200/TR3200.cpp
@@ -92,6 +92,10 @@ namespace vm {
     unsigned TR3200::RealStep() {
       unsigned wait_cycles;
 
+      if (vcomp->isBreakPoint(pc)) { // Breakpoint !
+        return 0;
+      }
+
       dword_t inst = vcomp->ReadDW(pc);
       pc +=4;
 

--- a/src/TR3200/TR3200.cpp
+++ b/src/TR3200/TR3200.cpp
@@ -63,9 +63,13 @@ namespace vm {
       while (i < n) {
         if (!sleeping) {
           if (wait_cycles <= 0 ) {
-            wait_cycles = RealStep();
+            RealStep();
           }
-
+#ifdef BRKPOINTS
+          if (vcomp->isHalted()) {
+            return;
+          }
+#endif
           wait_cycles--;
         } else {
           ProcessInterrupt();
@@ -91,7 +95,7 @@ namespace vm {
      * @return Number of cycles that takes to do it
      */
     unsigned TR3200::RealStep() {
-      unsigned wait_cycles;
+      //unsigned wait_cycles;
 
 #ifdef BRKPOINTS
       if (vcomp->isBreakPoint(pc)) { // Breakpoint !
@@ -538,7 +542,6 @@ namespace vm {
               break;
 
             case P2_OPCODE::CALL2 : // Absolute call
-              wait_cycles++;
               // push to the stack register pc value
               vcomp->WriteB(--r[SP], pc >> 24);
               vcomp->WriteB(--r[SP], pc >> 16);
@@ -619,7 +622,6 @@ namespace vm {
               break;
 
             case P1_OPCODE::CALL :  // Absolute call
-              wait_cycles++;
               // push to the stack register pc value
               vcomp->WriteB(--r[SP], pc >> 24);
               vcomp->WriteB(--r[SP], pc >> 16);
@@ -637,7 +639,6 @@ namespace vm {
               break;
 
             case P1_OPCODE::RCALL : // Relative call
-              wait_cycles++;
               // push to the stack register pc value
               vcomp->WriteB(--r[SP], pc >> 24);
               vcomp->WriteB(--r[SP], pc >> 16);
@@ -651,7 +652,6 @@ namespace vm {
 
 
             case P1_OPCODE::INT : // Software Interrupt
-              wait_cycles += 3;
               if (!literal) {
                 rn = r[rn];
               }
@@ -678,8 +678,6 @@ namespace vm {
               break;
 
             case NP_OPCODE::RFI :
-              wait_cycles = 6;
-
               // Pop PC
               pc = vcomp->ReadDW(r[SP]);
               r[SP] += 4;
@@ -694,8 +692,7 @@ namespace vm {
               break;
 
             default:
-              // Unknow OpCode -> Acts like a NOP
-              wait_cycles = 1;
+              break; // Unknow OpCode -> Acts like a NOP (this could change)
 
           }
         }

--- a/src/TR3200/TR3200.cpp
+++ b/src/TR3200/TR3200.cpp
@@ -8,6 +8,7 @@
 #include "TR3200/TR3200_opcodes.hpp"
 #include "TR3200/TR3200_macros.hpp"
 #include "VSFix.hpp"
+#include "Config.hpp"
 
 #include <cstdio>
 #include <algorithm>
@@ -92,9 +93,11 @@ namespace vm {
     unsigned TR3200::RealStep() {
       unsigned wait_cycles;
 
+#ifdef BRKPOINTS
       if (vcomp->isBreakPoint(pc)) { // Breakpoint !
         return 0;
       }
+#endif
 
       dword_t inst = vcomp->ReadDW(pc);
       pc +=4;

--- a/src/VComputer.cpp
+++ b/src/VComputer.cpp
@@ -17,7 +17,7 @@ namespace vm {
     using namespace vm::cpu;
 
     VComputer::VComputer (std::size_t ram_size ) :
-        is_on(false), ram(nullptr), rom(nullptr), ram_size(ram_size), rom_size(0), breaking(false) {
+        is_on(false), ram(nullptr), rom(nullptr), ram_size(ram_size), rom_size(0), breaking(false), recover_break(false) {
 
             ram = new byte_t[ram_size];
             std::fill_n(ram, ram_size, 0);

--- a/src/VComputer.cpp
+++ b/src/VComputer.cpp
@@ -1,5 +1,8 @@
-/**
- * Trillek Virtual Computer - VComputer.cpp
+/*!
+ * \brief       Virtual Computer Core
+ * \file        VComputer.cpp
+ * \copyright   The MIT License (MIT)
+ *
  * Virtual Computer core
  */
 

--- a/src/VComputer.cpp
+++ b/src/VComputer.cpp
@@ -8,6 +8,7 @@
 
 #include "VComputer.hpp"
 #include "VSFix.hpp"
+#include "Config.hpp"
 
 #include <algorithm>
 #include <cstdio>
@@ -167,9 +168,11 @@ namespace vm {
         if (is_on) {
             unsigned cpu_ticks = cpu->Step();
 
+#ifdef BRKPOINTS
             if (breaking) {
                 return 0; // We not executed yet the instruction!
             }
+#endif
 
             unsigned base_ticks = cpu_ticks * (BaseClock / cpu->Clock());
             unsigned dev_ticks = (base_ticks / 10); // Devices clock is at 100 KHz

--- a/src/VComputer.cpp
+++ b/src/VComputer.cpp
@@ -11,176 +11,242 @@
 #include <cassert>
 
 namespace vm {
-  using namespace vm::cpu;
+    using namespace vm::cpu;
 
-  VComputer::VComputer (std::size_t ram_size ) :
-      ram(nullptr), rom(nullptr), ram_size(ram_size), rom_size(0) {
+    VComputer::VComputer (std::size_t ram_size ) :
+        is_on(false), ram(nullptr), rom(nullptr), ram_size(ram_size), rom_size(0) {
 
-    ram = new byte_t[ram_size];
-    std::fill_n(ram, ram_size, 0);
+            ram = new byte_t[ram_size];
+            std::fill_n(ram, ram_size, 0);
 
-    // Add timers addresses
-    Range pit_range(0x11E000, 0x11E010);
-    AddAddrListener(pit_range, &pit);
+            // Add timers addresses
+            Range pit_range(0x11E000, 0x11E010);
+            AddAddrListener(pit_range, &pit);
 
-    // Add RNG address
-    Range rng_range(0x11E040, 0x11E043);
-    AddAddrListener(rng_range, &rng);
+            // Add RNG address
+            Range rng_range(0x11E040, 0x11E043);
+            AddAddrListener(rng_range, &rng);
 
-    // Add RTC address
-    Range rtc_range(0x11E030, 0x11E036);
-    AddAddrListener(rtc_range, &rtc);
-  }
-
-  VComputer::~VComputer () {
-    if (ram != nullptr)
-      delete[] ram;
-
-    // Drops plugged devices
-    for (unsigned i=0; i < MAX_N_DEVICES; i++) {
-      this->RmDevice(i);
-    }
-  }
-
-  void VComputer::SetCPU (std::unique_ptr<ICPU> cpu) {
-    this->cpu = std::move(cpu);
-    this->cpu->SetVComputer(this);
-  }
-
-  std::unique_ptr<ICPU> VComputer::RmCPU () {
-    this->cpu->SetVComputer(nullptr);
-    return std::move(cpu);
-  }
-
-  bool VComputer::AddDevice (unsigned slot , std::shared_ptr<IDevice> dev) {
-    if (slot >= MAX_N_DEVICES || std::get<0>(devices[slot])) {
-      return false;
-    }
-
-    // TODO See were store the pointer or use a shared_ptr
-    auto enumblk = new EnumAndCtrlBlk(slot, dev.get());
-    std::get<2>(devices[slot]) = this->AddAddrListener(enumblk->GetRange(), enumblk);
-    if (std::get<2>(devices[slot]) != -1) {
-      std::get<0>(devices[slot]) = dev;
-      dev->SetVComputer(this);
-      std::get<1>(devices[slot]) = enumblk;
-    } else { // Wops ! Problem!
-      delete enumblk;
-      return false;
-    }
-
-    return true;
-  }
-
-  std::shared_ptr<IDevice> VComputer::GetDevice (unsigned slot) {
-    if (slot >= MAX_N_DEVICES || !std::get<0>(devices[slot])) {
-      return nullptr;
-    }
-
-    return std::get<0>(devices[slot]);
-  }
-
-  void VComputer::RmDevice (unsigned slot) {
-    if (slot < MAX_N_DEVICES && std::get<0>(devices[slot])) {
-      std::get<0>(devices[slot])->SetVComputer(nullptr);
-      std::get<0>(devices[slot]).reset(); // Cleans the slot
-      delete std::get<1>(devices[slot]);
-      std::get<1>(devices[slot]) = nullptr;
-      std::get<2>(devices[slot]) = -1;
-    }
-  }
-
-  unsigned VComputer::CPUClock() const {
-    if (cpu) {
-      return cpu->Clock();
-    }
-    return 0;
-  }
-
-  void VComputer::GetState (void* ptr, std::size_t size) const {
-    if (cpu) {
-      return cpu->GetState(ptr, size);
-    }
-  }
-
-  void VComputer::SetROM (const byte_t* rom, std::size_t rom_size) {
-    assert (rom != nullptr);
-    assert (rom_size > 0);
-
-    this->rom = rom;
-    this->rom_size = (rom_size > MAX_ROM_SIZE) ? MAX_ROM_SIZE : rom_size;
-  }
-
-  void VComputer::Reset() {
-    if (cpu) {
-      cpu->Reset();
-    }
-
-    // Reset embed devices
-    pit.Reset();
-    rng.Reset();
-
-    // Reset devices
-    for (unsigned slot = 0; slot < MAX_N_DEVICES; slot++) {
-      if ( !std::get<0>(devices[slot])) {
-        continue;
-      }
-      std::get<0>(devices[slot])->Reset();
-    }
-  }
-
-  unsigned VComputer::Step( const double delta) {
-    if (cpu) {
-      unsigned cpu_ticks = cpu->Step();
-      unsigned base_ticks = cpu_ticks * (BaseClock / cpu->Clock());
-      unsigned dev_ticks = (base_ticks / 10); // Devices clock is at 100 KHz
-      pit.Tick(dev_ticks, delta);
-
-      word_t msg;
-      bool interrupted = pit.DoesInterrupt(msg); // Highest priority interrupt
-      if (interrupted) {
-        if (cpu->SendInterrupt(msg)) { // Send the interrupt to the CPU
-          pit.IACK();
-        }
-      }
-
-      for (std::size_t i=0; i < MAX_N_DEVICES; i++) {
-        if (! std::get<0>(devices[i])) {
-          continue; // Slot without device
+            // Add RTC address
+            Range rtc_range(0x11E030, 0x11E036);
+            AddAddrListener(rtc_range, &rtc);
         }
 
-        // Does the sync job
-        if ( std::get<0>(devices[i])->IsSyncDev()) {
-          std::get<0>(devices[i])->Tick(dev_ticks, delta);
-        }
+    VComputer::~VComputer () {
+        if (ram != nullptr)
+            delete[] ram;
 
-        // Try to get the highest priority interrupt
-        if (! interrupted && std::get<0>(devices[i])->DoesInterrupt(msg) ) {
-          interrupted = true;
-          if (cpu->SendInterrupt(msg)) { // Send the interrupt to the CPU
-            std::get<0>(devices[i])->IACK(); // Informs to the device that his interrupt has been accepted by the CPU
-          }
+        // Drops plugged devices
+        for (unsigned i=0; i < MAX_N_DEVICES; i++) {
+            this->RmDevice(i);
         }
-      }
-
-      return base_ticks;
     }
 
-    return 0;
-  }
-
-  int32_t VComputer::AddAddrListener (const Range& range, AddrListener* listener) {
-    assert(listener != nullptr);
-    if (listeners.insert(std::make_pair(range, listener)).second ) { // Correct insertion
-      return range.start;
+    void VComputer::SetCPU (std::unique_ptr<ICPU> cpu) {
+        this->cpu = std::move(cpu);
+        this->cpu->SetVComputer(this);
     }
-    return -1;
-  }
 
-  bool VComputer::RmAddrListener (int32_t id) {
-    Range r(id);
-    return listeners.erase(r) >= 1;
-  }
+    std::unique_ptr<ICPU> VComputer::RmCPU () {
+        this->cpu->SetVComputer(nullptr);
+        return std::move(cpu);
+    }
+
+    bool VComputer::AddDevice (unsigned slot , std::shared_ptr<IDevice> dev) {
+        if (slot >= MAX_N_DEVICES || std::get<0>(devices[slot])) {
+            return false;
+        }
+
+        // TODO See were store the pointer or use a shared_ptr
+        auto enumblk = new EnumAndCtrlBlk(slot, dev.get());
+        std::get<2>(devices[slot]) = this->AddAddrListener(enumblk->GetRange(), enumblk);
+        if (std::get<2>(devices[slot]) != -1) {
+            std::get<0>(devices[slot]) = dev;
+            dev->SetVComputer(this);
+            std::get<1>(devices[slot]) = enumblk;
+        } else { // Wops ! Problem!
+            delete enumblk;
+            return false;
+        }
+
+        return true;
+    }
+
+    std::shared_ptr<IDevice> VComputer::GetDevice (unsigned slot) {
+        if (slot >= MAX_N_DEVICES || !std::get<0>(devices[slot])) {
+            return nullptr;
+        }
+
+        return std::get<0>(devices[slot]);
+    }
+
+    void VComputer::RmDevice (unsigned slot) {
+        if (slot < MAX_N_DEVICES && std::get<0>(devices[slot])) {
+            std::get<0>(devices[slot])->SetVComputer(nullptr);
+            std::get<0>(devices[slot]).reset(); // Cleans the slot
+            delete std::get<1>(devices[slot]);
+            std::get<1>(devices[slot]) = nullptr;
+            std::get<2>(devices[slot]) = -1;
+        }
+    }
+
+    unsigned VComputer::CPUClock() const {
+        if (cpu) {
+            return cpu->Clock();
+        }
+        return 0;
+    }
+
+    void VComputer::GetState (void* ptr, std::size_t size) const {
+        if (cpu) {
+            return cpu->GetState(ptr, size);
+        }
+    }
+
+    void VComputer::SetROM (const byte_t* rom, std::size_t rom_size) {
+        assert (rom != nullptr);
+        assert (rom_size > 0);
+
+        this->rom = rom;
+        this->rom_size = (rom_size > MAX_ROM_SIZE) ? MAX_ROM_SIZE : rom_size;
+    }
+
+    void VComputer::Reset() {
+        if (cpu) {
+            cpu->Reset();
+        }
+
+        // Reset embed devices
+        pit.Reset();
+        rng.Reset();
+
+        // Reset devices
+        for (unsigned slot = 0; slot < MAX_N_DEVICES; slot++) {
+            if ( !std::get<0>(devices[slot])) {
+                continue;
+            }
+            std::get<0>(devices[slot])->Reset();
+        }
+    }
+
+    void VComputer::On() {
+        if (cpu && !is_on) { // Powering it wihtout cpu ?
+            is_on = true;
+            this->Reset(); // When we power on, we get a Reset!
+        }
+    }
+
+    void VComputer::Off() {
+        is_on = false;
+    }
+
+    unsigned VComputer::Update( const double delta) {
+        assert (delta > 0);
+
+        unsigned cycles = (vm::BaseClock * delta ) + 0.5f;
+        // +0.5 for rounding bug in VS
+
+        if (cycles <= 1) {
+            cycles = 1;
+        } else if (cycles >= 80000) {
+            cycles = 80000;
+        }
+
+        this->Tick(cycles, delta);
+        return cycles;
+    }
+
+    unsigned VComputer::Step( const double delta) {
+        if (is_on) {
+            unsigned cpu_ticks = cpu->Step();
+            unsigned base_ticks = cpu_ticks * (BaseClock / cpu->Clock());
+            unsigned dev_ticks = (base_ticks / 10); // Devices clock is at 100 KHz
+            pit.Tick(dev_ticks, delta);
+
+            word_t msg;
+            bool interrupted = pit.DoesInterrupt(msg); // Highest priority interrupt
+            if (interrupted) {
+                if (cpu->SendInterrupt(msg)) { // Send the interrupt to the CPU
+                    pit.IACK();
+                }
+            }
+
+            for (std::size_t i=0; i < MAX_N_DEVICES; i++) {
+                if (! std::get<0>(devices[i])) {
+                    continue; // Slot without device
+                }
+
+                // Does the sync job
+                if ( std::get<0>(devices[i])->IsSyncDev()) {
+                    std::get<0>(devices[i])->Tick(dev_ticks, delta);
+                }
+
+                // Try to get the highest priority interrupt
+                if (! interrupted && std::get<0>(devices[i])->DoesInterrupt(msg) ) {
+                    interrupted = true;
+                    if (cpu->SendInterrupt(msg)) { // Send the interrupt to the CPU
+                        std::get<0>(devices[i])->IACK(); // Informs to the device that his interrupt has been accepted by the CPU
+                    }
+                }
+            }
+
+            return base_ticks;
+        }
+
+        return 0;
+    }
+
+    void VComputer::Tick( unsigned n, const double delta) {
+        assert(n >0);
+        if (is_on) {
+            unsigned dev_ticks = n / 10; // Devices clock is at 100 KHz
+            unsigned cpu_ticks = n / (BaseClock / cpu->Clock());
+
+            cpu->Tick(cpu_ticks);
+            pit.Tick(dev_ticks, delta);
+
+            word_t msg;
+            bool interrupted = pit.DoesInterrupt(msg); // Highest priority interrupt
+            if (interrupted) {
+                if (cpu->SendInterrupt(msg)) { // Send the interrupt to the CPU
+                    pit.IACK();
+                }
+            }
+
+            for (std::size_t i=0; i < MAX_N_DEVICES; i++) {
+                if (! std::get<0>(devices[i])) {
+                    continue; // Slot without device
+                }
+
+                // Does the sync job
+                if ( std::get<0>(devices[i])->IsSyncDev()) {
+                    std::get<0>(devices[i])->Tick(dev_ticks, delta);
+                }
+
+                // Try to get the highest priority interrupt
+                if (! interrupted && std::get<0>(devices[i])->DoesInterrupt(msg) ) {
+                    interrupted = true;
+                    if (cpu->SendInterrupt(msg)) { // Send the interrupt to the CPU
+                        std::get<0>(devices[i])->IACK(); // Informs to the device that his interrupt has been accepted by the CPU
+                    }
+                }
+            }
+
+        }
+    }
+
+    int32_t VComputer::AddAddrListener (const Range& range, AddrListener* listener) {
+        assert(listener != nullptr);
+        if (listeners.insert(std::make_pair(range, listener)).second ) { // Correct insertion
+            return range.start;
+        }
+        return -1;
+    }
+
+    bool VComputer::RmAddrListener (int32_t id) {
+        Range r(id);
+        return listeners.erase(r) >= 1;
+    }
 
 } // End of namespace vm
 

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -94,8 +94,8 @@ int main(int argc, char* argv[]) {
     auto ddev = std::make_shared<vm::DummyDevice>();
     vc[i].AddDevice(10, ddev);
 
-    // Reset
-    vc[i].Reset();
+    // Powering itt
+    vc[i].On();
   }
 
   std::cout << "Randomizing every CPU!\nExecuting a random number of cycles from 1 to 255\n";

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,6 +6,7 @@ configure_file (./config_main.hpp.in
 
 add_executable( vm
   ./main.cpp
+  ./GlEngine.cpp
   )
 
 IF (GLFW3_ENABLE EQUAL 0)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -48,6 +48,7 @@ ELSE (GLFW3_ENABLE EQUAL 0)
     ${GLEW_INCLUDE_DIR}
     ${GLM_INCLUDE_DIR}
     ${GLFW3_INCLUDE_PATH}
+    "${CMAKE_CURRENT_SOURCE_DIR}/include/"
     )
 
   target_link_libraries( tda_view

--- a/tools/GlEngine.cpp
+++ b/tools/GlEngine.cpp
@@ -274,7 +274,7 @@ void GlEngine::UpdScreen (OS::OS& os, const double delta) {
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, screenTex);
 
-    if (t_acu >= 0.04) { // Updates screen texture at a rate of ~25 Hz
+    if (t_acu >= 0.04 || delta == 0) { // Updates screen texture at a rate of ~25 Hz
         t_acu -= 0.04;
 
         // Stream the texture *************************************************

--- a/tools/GlEngine.cpp
+++ b/tools/GlEngine.cpp
@@ -1,0 +1,353 @@
+/*!
+ * \brief       OpenGL Stuff of the test/toy emulator
+ * \file        GlEngine.cpp
+ * \copyright   The MIT License (MIT)
+ *
+ * OpenGL Stuff of the test/toy emulator.
+ */
+
+#include "GlEngine.hpp"
+
+const unsigned int GlEngine::sh_in_Position = 0;
+const unsigned int GlEngine::sh_in_Color = 1;
+const unsigned int GlEngine::sh_in_UV = 3;
+
+const GLfloat GlEngine::N_VERTICES = 4;
+
+const float GlEngine::vdata[] = {
+    3.2,  2.4, 0.0, // Top Right
+    -3.2,  2.4, 0.0, // Top Left
+    3.2, -2.4, 0.0, // Botton Right
+    -3.2, -2.4, 0.0, // Bottom Left
+};
+
+const float GlEngine::color_data[] = {
+    1.0,  1.0, 1.0, // Top Right
+    1.0,  1.0, 1.0, // Top Left
+    1.0,  1.0, 1.0, // Botton Right
+    1.0,  1.0, 1.0, // Bottom Left
+};
+
+const float GlEngine::uv_data[] = {
+    1.0,  0.0,      // Top Right
+    0.0,  0.0,      // Top Left
+    1.0,  1.0,      // Botton Right
+    0.0,  1.0,      // Bottom Left
+};
+
+
+void GlEngine::SetTextureCB (std::function<void(void*)> painter) {
+    this->painter = painter;
+}
+
+
+int GlEngine::initGL(OS::OS& os) {
+    int OpenGLVersion[2];
+
+    // Use the GL3 way to get the version number
+    glGetIntegerv(GL_MAJOR_VERSION, &OpenGLVersion[0]);
+    glGetIntegerv(GL_MINOR_VERSION, &OpenGLVersion[1]);
+    std::cout << "OpenGL " << OpenGLVersion[0] << "." << OpenGLVersion[1] << "\n";
+
+    // Sanity check to make sure we are at least in a good major version number.
+    assert((OpenGLVersion[0] > 1) && (OpenGLVersion[0] < 5));
+    if (OpenGLVersion[0] < 3 || (OpenGLVersion[0] == 3 && OpenGLVersion[1] < 2) ) {
+        std::cerr << "Error!\nWe need OpenGL 3.2 at least!";
+        return -1;
+    }
+
+    winWidth = os.GetWindowWidth();
+    winHeight = os.GetWindowHeight();
+
+    // Determine the aspect ratio and sanity check it to a safe ratio
+    GLfloat aspectRatio = static_cast<float>(winWidth) / static_cast<float>(winHeight);
+    if (aspectRatio < 1.0f) {
+        aspectRatio = 4.0f / 3.0f;
+    }
+
+    // Projection matrix : 45° Field of View
+    proj = glm::perspective(
+            45.0f,      // FOV
+            aspectRatio,
+            0.1f,       // Near cliping plane
+            10000.0f);  // Far cliping plane
+
+    glPolygonMode( GL_FRONT_AND_BACK, GL_FILL );
+#if __APPLE__
+    // GL_MULTISAMPLE are Core.
+    glEnable(GL_MULTISAMPLE);
+#else
+    if (GLEW_ARB_multisample) {
+        glEnable(GL_MULTISAMPLE_ARB);
+    }
+#endif
+    glEnable(GL_CULL_FACE);
+    glCullFace(GL_BACK);
+
+    glEnable(GL_DEPTH_TEST);
+    // Accept fragment if it closer to the camera than the former one
+    glDepthFunc(GL_LESS);
+
+    // Initialize VBOs ********************************************************
+    glGenBuffers(1, &vertexbuffer);
+    glBindBuffer(GL_ARRAY_BUFFER, vertexbuffer);
+    // Upload data to VBO
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vdata), vdata, GL_STATIC_DRAW);
+
+    glGenBuffers(1, &colorbuffer);
+    glBindBuffer(GL_ARRAY_BUFFER, colorbuffer);
+    // Upload data to VBO
+    glBufferData(GL_ARRAY_BUFFER, sizeof(color_data), color_data, GL_STATIC_DRAW);
+
+    glGenBuffers(1, &uvbuffer);
+    glBindBuffer(GL_ARRAY_BUFFER, uvbuffer);
+    // Upload data to VBO
+    glBufferData(GL_ARRAY_BUFFER, sizeof(uv_data), uv_data, GL_STATIC_DRAW);
+
+    // Initialize PBO *********************************************************
+    glGenBuffers(1, &tex_pbo);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, tex_pbo);
+    glBufferData(GL_PIXEL_UNPACK_BUFFER, 320*240*4, nullptr, GL_STREAM_DRAW);
+
+    // Initialize Texture *****************************************************
+    glGenTextures(1, &screenTex);
+    glBindTexture(GL_TEXTURE_2D, screenTex);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 320, 240, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+
+    //glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    //glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    // Loading shaders ********************************************************
+    // TODO paqth to shadersm should be a parameter
+    auto f_vs = std::fopen("./assets/shaders/mvp_template.vert", "r");
+    if (f_vs != nullptr) {
+        fseek(f_vs, 0L, SEEK_END);
+        size_t bufsize = ftell(f_vs);
+        vertexSource = new GLchar[bufsize + 1]();
+
+        fseek(f_vs, 0L, SEEK_SET);
+        auto t = fread(vertexSource, sizeof(GLchar), bufsize, f_vs);
+        if (t <= 0) {
+            std::cerr << "Error reading Vertex Shader\n";
+            return -1;
+        }
+
+        fclose(f_vs);
+        vertexSource[bufsize] = 0; // Enforce null char
+    }
+
+    //auto f_fs = std::fopen("./assets/shaders/basic_texture.frag", "r");
+    auto f_fs = std::fopen("./assets/shaders/retro_texture.frag", "r");
+    if (f_fs != nullptr) {
+        fseek(f_fs, 0L, SEEK_END);
+        size_t bufsize = ftell(f_fs);
+        fragmentSource = new GLchar[bufsize +1 ]();
+
+        fseek(f_fs, 0L, SEEK_SET);
+        auto t = fread(fragmentSource, sizeof(GLchar), bufsize, f_fs);
+        if (t <= 0) {
+            std::cerr << "Error reading Fragment Shader\n";
+            return -1;
+        }
+
+        fclose(f_fs);
+        fragmentSource[bufsize] = 0; // Enforce null char
+    }
+
+    // Assign our handles a "name" to new shader objects
+    vertexShader = glCreateShader(GL_VERTEX_SHADER);
+    fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
+
+    // Associate the source code buffers with each handle
+    glShaderSource(vertexShader, 1, (const GLchar**)&vertexSource, 0);
+    glShaderSource(fragmentShader, 1, (const GLchar**)&fragmentSource, 0);
+
+    // Compile our shader objects
+    glCompileShader(vertexShader);
+    glCompileShader(fragmentShader);
+
+    if (vertexSource != nullptr) {
+        delete[] vertexSource;
+        vertexSource = nullptr;
+    }
+
+    if (fragmentSource != nullptr) {
+        delete[] fragmentSource;
+        fragmentSource = nullptr;
+    }
+
+    GLint Result = GL_FALSE;
+    int InfoLogLength;
+
+    // Vertex Shader compiling error messages
+    glGetShaderiv(vertexShader, GL_COMPILE_STATUS, &Result);
+    glGetShaderiv(vertexShader, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    GLchar* vertexshader_error_msg = new GLchar(InfoLogLength +1);
+    glGetShaderInfoLog(vertexShader, InfoLogLength, NULL, vertexshader_error_msg);
+    if (vertexshader_error_msg[0] != '\0') { // Error compiling vertex shader
+        std::fprintf(stderr, "> %s\n", vertexshader_error_msg);
+        delete[] vertexshader_error_msg;
+        return -1;
+    }
+
+    // Fragment Shader compiling error messages
+    glGetShaderiv(fragmentShader, GL_COMPILE_STATUS, &Result);
+    glGetShaderiv(fragmentShader, GL_INFO_LOG_LENGTH, &InfoLogLength);
+    GLchar* fragmentshader_error_msg = new GLchar(InfoLogLength);
+    glGetShaderInfoLog(fragmentShader, InfoLogLength, NULL, fragmentshader_error_msg);
+    if (fragmentshader_error_msg[0] != '\0') { // Error compiling fragment shader
+        std::fprintf(stderr, "> %s\n", fragmentshader_error_msg);
+        delete[] fragmentshader_error_msg;
+        return -1;
+    }
+
+    // Assign our program handle a "name"
+    shaderProgram = glCreateProgram();
+
+    // Attach our shaders to our program
+    glAttachShader(shaderProgram, vertexShader);
+    glAttachShader(shaderProgram, fragmentShader);
+
+    // Link shader program
+    glLinkProgram(shaderProgram);
+
+    // Bind attributes indexes
+    glBindAttribLocation(shaderProgram, sh_in_Position, "in_Position");
+    glBindAttribLocation(shaderProgram, sh_in_Color, "in_Color");
+    glBindAttribLocation(shaderProgram, sh_in_UV, "in_UV");
+
+    modelId = glGetUniformLocation(shaderProgram, "in_Model");
+    viewId  = glGetUniformLocation(shaderProgram, "in_View");
+    projId  = glGetUniformLocation(shaderProgram, "in_Proj");
+
+    timeId = glGetUniformLocation(shaderProgram, "time");
+
+
+    glDeleteShader(vertexShader);
+    glDeleteShader(fragmentShader);
+
+
+    // Camera matrix
+    view = glm::lookAt(
+            glm::vec3(3,3,7), // Camera is at (3,3,7), in World Space
+            glm::vec3(0,0,0), // and looks at the origin
+            glm::vec3(0,1,0)  // Head is up (set to 0,-1,0 to look upside-down)
+            );
+
+    return 0;
+}
+
+void GlEngine::UpdScreen (OS::OS& os, const double delta) {
+    t_acu += delta;
+
+    // Clear The Screen And The Depth Buffer
+    frame_count += 1.0;
+
+    glClearColor( 0.1f, 0.1f, 0.1f, 1.0f );
+    glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    // Model matrix <- Identity
+    model = glm::mat4(1.0f);
+
+    // Camera Matrix
+    view = glm::lookAt(
+            glm::vec3(
+                (float)(zoom * sin(yaw)*cos(pith)),
+                (float)(zoom * sin(pith)),
+                (float)(zoom * cos(yaw))*cos(pith)), // Were is the camera
+            glm::vec3(0,0,0), // and looks at the origin
+            glm::vec3(0,1,0)  // Head is up (set to 0,-1,0 to look upside-down)
+            );
+
+    // Drawing ...
+    glUseProgram(shaderProgram);
+    // Set sampler to user Texture Unit 0
+    glUniform1i(glGetUniformLocation( shaderProgram, "texture0" ), 0);
+
+    // Bind texture
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, screenTex);
+
+    if (t_acu >= 0.04) { // Updates screen texture at a rate of ~25 Hz
+        t_acu -= 0.04;
+
+        // Stream the texture *************************************************
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, tex_pbo);
+
+        // Copy the PBO to the texture
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 320, 240, GL_RGBA, GL_UNSIGNED_BYTE, 0);
+
+        // Updates the PBO with the new texture
+        auto tdata = glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
+        if (tdata != nullptr) {
+            //std::fill_n(tdata, 320*240, 0xFF800000);
+            if (painter) {
+                painter(tdata);
+            }
+
+            glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+        }
+
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0); // Release the PBO
+    }
+
+    // Enable attribute in_Position as being used
+    glEnableVertexAttribArray(sh_in_Position);
+    glBindBuffer(GL_ARRAY_BUFFER, vertexbuffer);
+
+    // Vertex data to attribute index 0 (shadderAttribute) and is 3 floats
+    glVertexAttribPointer(
+            sh_in_Position,
+            3,
+            GL_FLOAT,
+            GL_FALSE,
+            0,
+            0 );
+
+    // Enable attribute in_Color as being used
+    glEnableVertexAttribArray(sh_in_Color);
+    glBindBuffer(GL_ARRAY_BUFFER, colorbuffer);
+    // Vertex data to attribute index 0 (shadderAttribute) and is 3 floats
+    glVertexAttribPointer(
+            sh_in_Color,
+            3,
+            GL_FLOAT,
+            GL_FALSE,
+            0,
+            0 );
+
+    // Enable attribute in_UV as being used
+    glEnableVertexAttribArray(sh_in_UV);
+    glBindBuffer(GL_ARRAY_BUFFER, uvbuffer);
+    // Vertex data to attribute index 0 (shadderAttribute) and is 3 floats
+    glVertexAttribPointer(
+            sh_in_UV,
+            2,
+            GL_FLOAT,
+            GL_FALSE,
+            0,
+            0 );
+
+    // Send M, V, P matrixes to the uniform inputs,
+    glUniformMatrix4fv(modelId, 1, GL_FALSE, &model[0][0]);
+    glUniformMatrix4fv(viewId, 1, GL_FALSE, &view[0][0]);
+    glUniformMatrix4fv(projId, 1, GL_FALSE, &proj[0][0]);
+
+    glUniform1f(timeId, (float)((int)frame_count +1));
+
+    glDrawArrays(GL_TRIANGLE_STRIP, sh_in_Position, N_VERTICES);
+
+    glDisableVertexAttribArray(sh_in_Position);
+    glDisableVertexAttribArray(sh_in_Color);
+    glDisableVertexAttribArray(sh_in_UV);
+
+    // Update host window
+    os.SwapBuffers();
+    os.OSMessageLoop();
+}
+
+

--- a/tools/GlEngine.cpp
+++ b/tools/GlEngine.cpp
@@ -8,6 +8,8 @@
 
 #include "GlEngine.hpp"
 
+#ifdef GLFW3_ENABLE
+
 const unsigned int GlEngine::sh_in_Position = 0;
 const unsigned int GlEngine::sh_in_Color = 1;
 const unsigned int GlEngine::sh_in_UV = 3;
@@ -350,4 +352,5 @@ void GlEngine::UpdScreen (OS::OS& os, const double delta) {
     os.OSMessageLoop();
 }
 
+#endif
 

--- a/tools/config_main.hpp.in
+++ b/tools/config_main.hpp.in
@@ -32,6 +32,7 @@
 
     #include <GLFW/glfw3.h>
 
+    #define GLM_FORCE_RADIANS  // Removes anoying messages of depracated angles on degress
     #include <glm/glm.hpp>
     #include <glm/ext.hpp>
 

--- a/tools/config_main.hpp.in
+++ b/tools/config_main.hpp.in
@@ -8,32 +8,32 @@
 #ifndef ___CONFIG_MAIN_HPP__
 #define ___CONFIG_MAIN_HPP__ 1
 
-#define		GLFW3_ENABLE @GLFW3_ENABLE@
+#define   GLFW3_ENABLE @GLFW3_ENABLE@
 #if GLFW3_ENABLE == 0
-	#undef GLFW3_ENABLE
+    #undef GLFW3_ENABLE
 #else
 
-  #ifdef __APPLE__
-  	// Needed so we can disable retina support for our window.
-		#define GLFW_EXPOSE_NATIVE_COCOA 1
-		#define GLFW_EXPOSE_NATIVE_NSGL 1
-		#include <GLFW/glfw3native.h>
-  	// We can't just include objc/runtime.h and objc/message.h because glfw is too forward thinking for its own good.
-  	typedef void* SEL;
-  	extern "C" id objc_msgSend(id self, SEL op, ...);
-  	extern "C" SEL sel_getUid(const char *str);
-	#else
-		#include <GL/glew.h>
+    #ifdef __APPLE__
+        // Needed so we can disable retina support for our window.
+        #define GLFW_EXPOSE_NATIVE_COCOA 1
+        #define GLFW_EXPOSE_NATIVE_NSGL 1
+        #include <GLFW/glfw3native.h>
+        // We can't just include objc/runtime.h and objc/message.h because glfw is too forward thinking for its own good.
+        typedef void* SEL;
+        extern "C" id objc_msgSend(id self, SEL op, ...);
+        extern "C" SEL sel_getUid(const char *str);
+    #else
+        #include <GL/glew.h>
 
-		#ifndef __unix
-			#include <GL/wglew.h>
-		#endif
-  #endif
+        #ifndef __unix
+            #include <GL/wglew.h>
+        #endif
+    #endif
 
-	#include <GLFW/glfw3.h>
+    #include <GLFW/glfw3.h>
 
-	#include <glm/glm.hpp>
-  #include <glm/ext.hpp>
+    #include <glm/glm.hpp>
+    #include <glm/ext.hpp>
 
 #endif
 

--- a/tools/include/GlEngine.hpp
+++ b/tools/include/GlEngine.hpp
@@ -57,6 +57,13 @@ public:
      */
     void UpdScreen (OS::OS& os, const double delta);
 
+    /*!
+     * Handles that the Virtual computer is halted by abreakpoitn or something
+     */
+    void Halted() {
+        t_acu = 0;
+    }
+
 private:
     unsigned winWidth;
     unsigned winHeight;

--- a/tools/include/GlEngine.hpp
+++ b/tools/include/GlEngine.hpp
@@ -1,0 +1,114 @@
+#pragma once
+/*!
+ * \brief       OpenGL Stuff of the test/toy emulator
+ * \file        GlEngine.hpp
+ * \copyright   The MIT License (MIT)
+ *
+ * OpenGL Stuff of the test/toy emulator.
+ */
+
+#include "OS.hpp"
+
+#include <iostream>
+#include <functional>
+
+#include <cassert>
+
+#ifdef GLFW3_ENABLE
+
+class GlEngine {
+public:
+    GlEngine () {
+        winWidth  = 0;
+        winHeight = 0;
+
+        vertexSource = nullptr;
+        fragmentSource = nullptr;
+
+        yaw  = 0;
+        pith = 0;
+        zoom = 6.0;
+
+        frame_count = 0;
+        t_acu = 0;
+    }
+
+    ~GlEngine () {
+        // RAII
+        if (vertexSource != nullptr) {
+            delete[] vertexSource;
+        }
+
+        if (fragmentSource != nullptr) {
+            delete[] fragmentSource;
+        }
+    }
+
+    //! Init OpenGL
+    int initGL(OS::OS& os);
+
+    //! Sets the Painter function of screen texture
+    void SetTextureCB (std::function<void(void*)> painter);
+
+    /*!
+     * Updates the whole screen
+     * \param os
+     * \param delta delta in seconds
+     */
+    void UpdScreen (OS::OS& os, const double delta);
+
+private:
+    unsigned winWidth;
+    unsigned winHeight;
+
+    //bool capture_keyboard = false;
+
+    GLuint screenTex; // ID of screen Texture
+    GLuint tex_pbo;   // ID of the screen texture PBO
+
+    // Handler of shader program
+    GLuint shaderProgram;
+
+    // Ptrs to source doe of shaders
+    GLchar* vertexSource;
+    GLchar* fragmentSource;
+
+    // Handlers of the shader programs
+    GLuint vertexShader;
+    GLuint fragmentShader;
+
+    // Handles for uniform inputs to the shader
+    GLuint modelId;
+    GLuint viewId;
+    GLuint projId;
+    GLuint timeId;
+
+    static const unsigned int sh_in_Position;
+    static const unsigned int sh_in_Color;
+    static const unsigned int sh_in_UV;
+
+    static const GLfloat N_VERTICES;
+
+    GLuint vertexbuffer;
+    static const float vdata[];
+
+    GLuint colorbuffer;
+    static const float color_data[];
+
+    GLuint uvbuffer;
+    static const float uv_data[];
+
+    glm::mat4 proj, view, model; //! MVP Matrixes
+
+    float yaw;
+    float pith;
+    float zoom;
+
+    float frame_count;  //! Count frames
+    double t_acu;       //! Acumulated time
+
+    std::function<void(void*)> painter; //! Function that paints screen texture
+};
+
+#endif
+

--- a/tools/include/GlEngine.hpp
+++ b/tools/include/GlEngine.hpp
@@ -57,13 +57,6 @@ public:
      */
     void UpdScreen (OS::OS& os, const double delta);
 
-    /*!
-     * Handles that the Virtual computer is halted by abreakpoitn or something
-     */
-    void Halted() {
-        t_acu = 0;
-    }
-
 private:
     unsigned winWidth;
     unsigned winHeight;

--- a/tools/include/OS.hpp
+++ b/tools/include/OS.hpp
@@ -1,5 +1,9 @@
 #pragma once
-/**
+/*!
+ * \brief       Stuff to create GLFW window and gestionate it
+ * \file        OS.hpp
+ * \copyright   The MIT License (MIT)
+ *
  * Stuff to create GLFW window and gestionate it
  */
 
@@ -19,274 +23,274 @@
 #include <cstdio>
 
 namespace OS {
-  class OS {
-  public:
-    OS() : mouseLock(false) {
-      this->lastTime = glfwGetTime(); // Better that garbage...
-    }
+    class OS {
+        public:
+            OS() : mouseLock(false) {
+                this->lastTime = glfwGetTime(); // Better that garbage...
+            }
 
-    ~OS() { }
+            ~OS() { }
 
-    bool InitializeWindow(const int width, const int height, const std::string title, const unsigned int glMajor = 3, const unsigned int glMinor = 2) {
-      // Initialize the library.
-      if (glfwInit() != GL_TRUE) {
-        return false;
-      }
+            bool InitializeWindow(const int width, const int height, const std::string title, const unsigned int glMajor = 3, const unsigned int glMinor = 2) {
+                // Initialize the library.
+                if (glfwInit() != GL_TRUE) {
+                    return false;
+                }
 
-      glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
-      glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-      glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, glMajor);
-      glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, glMinor);
+                glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
+                glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+                glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, glMajor);
+                glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, glMinor);
 
 #ifdef __APPLE__
-      // Must use the Core Profile on OS X to get GL 3.2.
-      glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+                // Must use the Core Profile on OS X to get GL 3.2.
+                glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #else
-      glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_COMPAT_PROFILE);
+                glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_COMPAT_PROFILE);
 #endif
 
-      // Create a windowed mode window and its OpenGL context.
-      this->window = glfwCreateWindow(width, height, title.c_str(), NULL, NULL);
+                // Create a windowed mode window and its OpenGL context.
+                this->window = glfwCreateWindow(width, height, title.c_str(), NULL, NULL);
 
-      if (!this->window) {
-        glfwTerminate();
-        return false;
-      }
+                if (!this->window) {
+                    glfwTerminate();
+                    return false;
+                }
 
-      this->width = width;
-      this->height = height;
+                this->width = width;
+                this->height = height;
 
 #ifdef __APPLE__
-      // Force retina displays to create a 1x framebuffer so we don't choke our fillrate.
-      id cocoaWindow = glfwGetCocoaWindow(this->window);
-      id cocoaGLView = ((id (*)(id, SEL)) objc_msgSend)(cocoaWindow, sel_getUid("contentView"));
-      ((void (*)(id, SEL, bool)) objc_msgSend)(cocoaGLView, sel_getUid("setWantsBestResolutionOpenGLSurface:"), false);
+                // Force retina displays to create a 1x framebuffer so we don't choke our fillrate.
+                id cocoaWindow = glfwGetCocoaWindow(this->window);
+                id cocoaGLView = ((id (*)(id, SEL)) objc_msgSend)(cocoaWindow, sel_getUid("contentView"));
+                ((void (*)(id, SEL, bool)) objc_msgSend)(cocoaGLView, sel_getUid("setWantsBestResolutionOpenGLSurface:"), false);
 #endif
 
-      // Make the window's context current.
-      glfwMakeContextCurrent(this->window);
+                // Make the window's context current.
+                glfwMakeContextCurrent(this->window);
 
 #ifndef __APPLE__
-      // setting glewExperimental fixes a glfw context problem
-      // (tested on Ubuntu 13.04)
-      glewExperimental = GL_TRUE;
+                // setting glewExperimental fixes a glfw context problem
+                // (tested on Ubuntu 13.04)
+                glewExperimental = GL_TRUE;
 
-      // Init GLEW.
-      GLuint error = glewInit();
-      if (error != GLEW_OK) {
-        return false;
-      }
+                // Init GLEW.
+                GLuint error = glewInit();
+                if (error != GLEW_OK) {
+                    return false;
+                }
 #endif
 
-      // Associate a pointer for this instance with this window.
-      glfwSetWindowUserPointer(this->window, this);
+                // Associate a pointer for this instance with this window.
+                glfwSetWindowUserPointer(this->window, this);
 
-      // Set up some callbacks.
-      glfwSetWindowSizeCallback(this->window, &OS::windowResized);
+                // Set up some callbacks.
+                glfwSetWindowSizeCallback(this->window, &OS::windowResized);
 
-      glfwSetKeyCallback(this->window, &keyboardEvent);
-      //glfwSetCursorPosCallback(this->window, &OSmouseMoveEvent);
-      glfwSetCharCallback(this->window, &characterEvent);
-      //glfwSetMouseButtonCallback(this->window, &mouseButtonEvent);
-      //glfwSetWindowFocusCallback(this->window, &windowFocusChange);
+                glfwSetKeyCallback(this->window, &keyboardEvent);
+                //glfwSetCursorPosCallback(this->window, &OSmouseMoveEvent);
+                glfwSetCharCallback(this->window, &characterEvent);
+                //glfwSetMouseButtonCallback(this->window, &mouseButtonEvent);
+                //glfwSetWindowFocusCallback(this->window, &windowFocusChange);
 
-      glfwGetCursorPos(this->window, &this->oldMouseX, &this->oldMouseY);
+                glfwGetCursorPos(this->window, &this->oldMouseX, &this->oldMouseY);
 
-      return true;
-    }
+                return true;
+            }
 
-    void Terminate() {
-      glfwTerminate();
-    }
+            void Terminate() {
+                glfwTerminate();
+            }
 
-    bool Closing() {
-      return glfwWindowShouldClose(this->window) > 0;
-    }
+            bool Closing() {
+                return glfwWindowShouldClose(this->window) > 0;
+            }
 
-    void SwapBuffers() {
-      glfwSwapBuffers(this->window);
-    }
+            void SwapBuffers() {
+                glfwSwapBuffers(this->window);
+            }
 
-    void OSMessageLoop() {
-      glfwPollEvents();
-    }
+            void OSMessageLoop() {
+                glfwPollEvents();
+            }
 
-    int GetWindowWidth() {
-      return this->width;
-    }
+            int GetWindowWidth() {
+                return this->width;
+            }
 
-    int GetWindowHeight() {
-      return this->height;
-    }
+            int GetWindowHeight() {
+                return this->height;
+            }
 
-    GLFWwindow* GetWindow() {
-      return this->window;
-    }
+            GLFWwindow* GetWindow() {
+                return this->window;
+            }
 
-    /**
-     * Return delta time in SECONDS
-     */
-    double GetDeltaTime() {
-      double time = glfwGetTime();
-      double delta = time - this->lastTime;
-      this->lastTime = time;
-      return delta;
-    }
+            /**
+             * Return delta time in SECONDS
+             */
+            double GetDeltaTime() {
+                double time = glfwGetTime();
+                double delta = time - this->lastTime;
+                this->lastTime = time;
+                return delta;
+            }
 
 
-    void UpdateWindowSize(const int width, const int height) {
-      this->width = width;
-      this->height = height;
-    }
+            void UpdateWindowSize(const int width, const int height) {
+                this->width = width;
+                this->height = height;
+            }
 
-    /**
-     * \brief Callback for when the window is resized.
-     *
-     * \param[in] GLFWwindow * window
-     * \param[in] int width, height The new client width and height of the window.
-     * \return void
-     */
-    static void windowResized(GLFWwindow* window, int width, int height) {
-      // Enforces desired size
-      // Get the user pointer and cast it.
-      OS* os = static_cast<OS*>(glfwGetWindowUserPointer(window));
-      if (os) {
-        if (width != os->width || height != os->height) {
-          glfwSetWindowSize(window, os->width, os->height);
-        }
-      }
-    }
+            /**
+             * \brief Callback for when the window is resized.
+             *
+             * \param[in] GLFWwindow * window
+             * \param[in] int width, height The new client width and height of the window.
+             * \return void
+             */
+            static void windowResized(GLFWwindow* window, int width, int height) {
+                // Enforces desired size
+                // Get the user pointer and cast it.
+                OS* os = static_cast<OS*>(glfwGetWindowUserPointer(window));
+                if (os) {
+                    if (width != os->width || height != os->height) {
+                        glfwSetWindowSize(window, os->width, os->height);
+                    }
+                }
+            }
 
-    /**
-     * \brief Callback for keyboard events.
-     *
-     * \param[in] GLFWwindow * window
-     * \param[in] int key ASCII key number.
-     * \param[in] int scancode The converted key value
-     * \param[in] int action The event type.
-     * \param[in] int mods Modifier keys.
-     * \return void
-     */
-    static void keyboardEvent(GLFWwindow* window, int key, int scancode, int action, int mods) {
-      // Get the user pointer and cast it.
-      OS* os = static_cast<OS*>(glfwGetWindowUserPointer(window));
+            /**
+             * \brief Callback for keyboard events.
+             *
+             * \param[in] GLFWwindow * window
+             * \param[in] int key ASCII key number.
+             * \param[in] int scancode The converted key value
+             * \param[in] int action The event type.
+             * \param[in] int mods Modifier keys.
+             * \return void
+             */
+            static void keyboardEvent(GLFWwindow* window, int key, int scancode, int action, int mods) {
+                // Get the user pointer and cast it.
+                OS* os = static_cast<OS*>(glfwGetWindowUserPointer(window));
 
-      if (os) {
-        os->DispatchKeyboardEvent(key, scancode, action, mods);
-      }
+                if (os) {
+                    os->DispatchKeyboardEvent(key, scancode, action, mods);
+                }
 
-    }
-    /**
-     * \brief Callback for unicode character event.
-     *
-     * This is different from just a normal keyboard event as it has been translated and modified by
-     * the OS and is just like typing into a text editor.
-     * \param[in] GLFWwindow * window
-     * \param[in] unsigned int uchar The unicode character key code.
-     * \return void
-     */
-    static void characterEvent(GLFWwindow* window, unsigned int uchar) {
-      // Get the user pointer and cast it.
-      OS* os = static_cast<OS*>(glfwGetWindowUserPointer(window));
+            }
+            /**
+             * \brief Callback for unicode character event.
+             *
+             * This is different from just a normal keyboard event as it has been translated and modified by
+             * the OS and is just like typing into a text editor.
+             * \param[in] GLFWwindow * window
+             * \param[in] unsigned int uchar The unicode character key code.
+             * \return void
+             */
+            static void characterEvent(GLFWwindow* window, unsigned int uchar) {
+                // Get the user pointer and cast it.
+                OS* os = static_cast<OS*>(glfwGetWindowUserPointer(window));
 
-      if (os) {
-        os->DispatchCharacterEvent(uchar);
-      }
-    }
+                if (os) {
+                    os->DispatchCharacterEvent(uchar);
+                }
+            }
 
-    /**
-     * \brief Callback for window focus change events.
-     *
-     * \param[in/out] GLFWwindow * window
-     * \param[in/out] int focused GL_TRUE if focused, GL_FALSE if unfocused.
-     * \return void
-     */
-    static void windowFocusChange(GLFWwindow* window, int focused) {
-      if (focused == GL_FALSE) {
-        // Get the user pointer and cast it.
-        OS* os = static_cast<OS*>(glfwGetWindowUserPointer(window));
+            /**
+             * \brief Callback for window focus change events.
+             *
+             * \param[in/out] GLFWwindow * window
+             * \param[in/out] int focused GL_TRUE if focused, GL_FALSE if unfocused.
+             * \return void
+             */
+            static void windowFocusChange(GLFWwindow* window, int focused) {
+                if (focused == GL_FALSE) {
+                    // Get the user pointer and cast it.
+                    OS* os = static_cast<OS*>(glfwGetWindowUserPointer(window));
 
-        if (os) {
-          os->KeyboardEventSystem.LostKeyboardFocus();
-        }
-      }
-    }
+                    if (os) {
+                        os->KeyboardEventSystem.LostKeyboardFocus();
+                    }
+                }
+            }
 
-    void RegisterKeyboardEventHandler(event::IKeyboardEventHandler* handler) {
-      this->KeyboardEventSystem.Register(handler);
-    }
+            void RegisterKeyboardEventHandler(event::IKeyboardEventHandler* handler) {
+                this->KeyboardEventSystem.Register(handler);
+            }
 
-    bool HasKeyboardFocusLock() {
-      return this->KeyboardEventSystem.HasFocusLock();
-    }
+            bool HasKeyboardFocusLock() {
+                return this->KeyboardEventSystem.HasFocusLock();
+            }
 
-    void ToggleMouseLock() {
-      this->mouseLock = !this->mouseLock;
-      if (this->mouseLock) {
-        glfwSetInputMode(this->window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
-      }
-      else {
-        glfwSetInputMode(this->window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
-      }
-    }
+            void ToggleMouseLock() {
+                this->mouseLock = !this->mouseLock;
+                if (this->mouseLock) {
+                    glfwSetInputMode(this->window, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+                }
+                else {
+                    glfwSetInputMode(this->window, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+                }
+            }
 
-    void SetMousePosition(double x, double y) {
-      glfwSetCursorPos(this->window, x, y);
-    }
+            void SetMousePosition(double x, double y) {
+                glfwSetCursorPos(this->window, x, y);
+            }
 
-    bool CheckKeyState(event::KEY_STATE state, const int key) {
-      if (state == event::KS_DOWN) {
-        if (glfwGetKey(this->window, key) == GLFW_PRESS) {
-          return true;
-        }
-      } else {
-        if (glfwGetKey(this->window, key) == GLFW_RELEASE) {
-          return true;
-        }
-      }
+            bool CheckKeyState(event::KEY_STATE state, const int key) {
+                if (state == event::KS_DOWN) {
+                    if (glfwGetKey(this->window, key) == GLFW_PRESS) {
+                        return true;
+                    }
+                } else {
+                    if (glfwGetKey(this->window, key) == GLFW_RELEASE) {
+                        return true;
+                    }
+                }
 
-      return false;
-    }
+                return false;
+            }
 
-  private:
+        private:
 
-    /**
-     * \brief Dispatches keyboard events from the callback.
-     *
-     * \param[in] const int key ASCII key number.
-     * \param[in] const int scancode The converted key value
-     * \param[in] const int action The event type.
-     * \param[in] const int mods Modifier keys.
-     * \return void
-     */
-    void DispatchKeyboardEvent(const int key, const int scancode, const int action, const int mods) {
-      if (action == GLFW_PRESS) {
-        KeyboardEventSystem.KeyDown(key);
-      }else if (action == GLFW_REPEAT) {
-        KeyboardEventSystem.KeyRepeat(key);
-      } else if (action == GLFW_RELEASE) {
-        KeyboardEventSystem.KeyUp(key);
-      }
-    }
+            /**
+             * \brief Dispatches keyboard events from the callback.
+             *
+             * \param[in] const int key ASCII key number.
+             * \param[in] const int scancode The converted key value
+             * \param[in] const int action The event type.
+             * \param[in] const int mods Modifier keys.
+             * \return void
+             */
+            void DispatchKeyboardEvent(const int key, const int scancode, const int action, const int mods) {
+                if (action == GLFW_PRESS) {
+                    KeyboardEventSystem.KeyDown(key);
+                }else if (action == GLFW_REPEAT) {
+                    KeyboardEventSystem.KeyRepeat(key);
+                } else if (action == GLFW_RELEASE) {
+                    KeyboardEventSystem.KeyUp(key);
+                }
+            }
 
-    /**
-     * \brief Dispatches a character event.
-     *
-     * \param[in] const unsigned int uchar The unicode character key code.
-     * \return void
-     */
-    void DispatchCharacterEvent(const unsigned int uchar) {
-      this->KeyboardEventSystem.CharDown(uchar);
-    }
+            /**
+             * \brief Dispatches a character event.
+             *
+             * \param[in] const unsigned int uchar The unicode character key code.
+             * \return void
+             */
+            void DispatchCharacterEvent(const unsigned int uchar) {
+                this->KeyboardEventSystem.CharDown(uchar);
+            }
 
-    GLFWwindow* window;
-    int width, height; // Current window's client width and height.
-    double oldMouseX, oldMouseY;
-    double lastTime; // The time at the last call to GetDeltaTime().
-    bool mouseLock; // If mouse lock is enabled causing the cursor to snap to mid-window each movement event.
+            GLFWwindow* window;
+            int width, height; // Current window's client width and height.
+            double oldMouseX, oldMouseY;
+            double lastTime; // The time at the last call to GetDeltaTime().
+            bool mouseLock; // If mouse lock is enabled causing the cursor to snap to mid-window each movement event.
 
-    event::KeyboardInputSystem KeyboardEventSystem;
-  };
+            event::KeyboardInputSystem KeyboardEventSystem;
+    };
 
 } // End of namespace OS
 

--- a/tools/include/VmParser.hpp
+++ b/tools/include/VmParser.hpp
@@ -24,6 +24,7 @@ struct VmParamaters {
 
     VmParamaters (const int argc, const char** argv) {
         dsk_file = def_dsk_file;
+        rom_file = nullptr;
 
         for (int i = 1; i < argc; i++) {
             const char* arg = argv[i];
@@ -141,6 +142,11 @@ struct VmParamaters {
                     ask_help = true;
                 }
             }
+        }
+
+        if (rom_file == nullptr) {
+            valid_params = false;
+            std::fprintf(stderr, "Missing ROM file\n");
         }
     }
 

--- a/tools/include/VmParser.hpp
+++ b/tools/include/VmParser.hpp
@@ -1,0 +1,145 @@
+#pragma once
+/*!
+ * \brief       Parameters parser for vm tool (main.cpp)
+ * \file        VmParser.hpp
+ * \copyright   The MIT License (MIT)
+ *
+ * Parameters parser for vm tool (main.cpp)
+ */
+
+#include <cstring>
+#include <cstdlib>
+#include <cstdio>
+
+enum class CpuToUse {
+    TR3200,
+    DCPU16N
+};
+
+struct VmParamaters {
+
+    VmParamaters (const int argc, const char** argv) {
+        dsk_file = def_dsk_file;
+
+        for (int i = 1; i < argc; i++) {
+            const char* arg = argv[i];
+
+            if (arg[0] == '-') { // Parameter
+                if (arg[1] == '\0') {
+                    valid_params = false;
+                    std::fprintf(stderr, "Invalid parameter %s\n", argv[i]);
+                    break; // Invalid parameter
+                }
+                arg++;
+
+                if (strncmp(arg, "r", 1) == 0 || strncmp(arg, "-rom", 4) == 0) {
+                    // Rom file parameter
+                    i++;
+                    arg = argv[i];
+                    if (i >= argc || arg[0] == '-') {
+                        valid_params = false;
+                        std::fprintf(stderr, "Missing or invalid value for parameter %s\n", argv[i-1]);
+                        break;
+                    }
+
+                    rom_file = arg;
+
+                } else if (strncmp(arg, "d", 1) == 0 || strncmp(arg, "-disk", 5) == 0) {
+                    // Disk file parameter
+                    i++;
+                    arg = argv[i];
+                    if (i >= argc || arg[0] == '-') {
+                        valid_params = false;
+                        std::fprintf(stderr, "Missing or invalid value for parameter %s\n", argv[i-1]);
+                        break;
+                    }
+
+                    dsk_file = arg;
+
+                } else if (strncmp(arg, "c", 1) == 0 || strncmp(arg, "-cpu", 4) == 0) {
+                    // CPU type
+                    i++;
+                    arg = argv[i];
+                    if (i >= argc || arg[0] == '-') {
+                        valid_params = false;
+                        std::fprintf(stderr, "Missing or invalid value for parameter %s\n", argv[i-1]);
+                        break;
+                    }
+
+                    if (strncmp(arg, "tr3200", 6) == 0 || strncmp(arg, "TR3200", 6) == 0) {
+                        cpu = CpuToUse::TR3200;
+                    } else if (strncmp(arg, "DCPU-16N", 6) == 0 || strncmp(arg, "dcpu-16n", 6) == 0) {
+                        cpu = CpuToUse::DCPU16N;
+                    }
+
+                } else if (strncmp(arg, "m", 1) == 0 ) {
+                    // Total RAM
+                    i++;
+                    arg = argv[i];
+                    if (i >= argc || arg[0] == '-') {
+                        valid_params = false;
+                        std::fprintf(stderr, "Missing or invalid value for parameter %s\n", argv[i-1]);
+                        break;
+                    }
+                    auto ram = std::atoi(arg);
+                    if (ram <= 0 || ram > 1024) {
+                        std::fprintf(stderr, "Invalid value for parameter %s\nUsing 128KiB\n", argv[i-1]);
+                        ram = 128*1024;
+                    } else {
+                        ram /= 128; // I hope the compile optimization don't trash this
+                        ram *= 128;
+                    }
+
+                    ram_size = ram * 1024;
+                } else if (strncmp(arg, "-clock", 6) == 0 ) {
+                    // Clock speed
+                    i++;
+                    arg = argv[i];
+                    if (i >= argc || arg[0] == '-') {
+                        valid_params = false;
+                        std::fprintf(stderr, "Missing or invalid value for parameter %s\n", argv[i-1]);
+                        break;
+                    }
+                    auto clk = std::atoi(arg);
+                    if (clk != 100 && clk != 250 && clk != 500 && clk != 1000) {
+                        std::fprintf(stderr, "Invalid value for parameter %s\nUsing 100KHz\n", argv[i-1]);
+                        clk = 1100;
+                    }
+
+                    clock = clk * 1000;
+
+                } else if (strncmp(arg, "h", 1) == 0 || strncmp(arg, "-help", 5) == 0) {
+                    // Asked for help
+                    std::printf("Virtual Computer toy Emulator\n\n");
+                    std::printf("Usage:\n");
+                    std::printf("\t%s -r romfile [other parameters]\n\n", argv[0]);
+                    std::printf("Parameters:\n");
+                    std::printf("\t-r file or --rom file : RAW binary file for the ROM 32 KiB\n");
+                    std::printf("\t-d file or --disk file : Disk file\n");
+                    std::printf("\t-c val or --cpu val : Sets the CPU to use, from \"tr3200\" or \"dcpu-16n\"\n");
+                    std::printf("\t-m val or --disk val : How many RAM have the computer in KiB. Must be > 128 and < 1024. Will be round to a multiple of 128\n");
+                    std::printf("\t--clock val : CPU clock speed in Khz. Must be 100, 250, 500 or 1000.\n");
+                    std::printf("\t-h or --help : Shows this help\n");
+
+                    ask_help = true;
+                }
+            }
+        }
+    }
+
+    const char* def_dsk_file = "disk.dsk";
+
+    const char* rom_file;           //! Path to ROM file
+    const char* dsk_file;           //! Path to Floppy disk file
+
+    unsigned ram_size = 128*1024;   //! Ram size in Bytes
+
+    CpuToUse cpu;                   //! CPU to use (default TR3200)
+    unsigned clock = 100000;        //! CPU clock speed (default 100Khz)
+
+
+    bool valid_params = true;       //! Parsed correctly all parameters
+    bool ask_help = false;          //! User asked by help
+};
+
+

--- a/tools/include/VmParser.hpp
+++ b/tools/include/VmParser.hpp
@@ -7,9 +7,13 @@
  * Parameters parser for vm tool (main.cpp)
  */
 
+#include "Types.hpp"
+
 #include <cstring>
 #include <cstdlib>
 #include <cstdio>
+
+#include <vector>
 
 enum class CpuToUse {
     TR3200,
@@ -81,7 +85,7 @@ struct VmParamaters {
                         std::fprintf(stderr, "Missing or invalid value for parameter %s\n", argv[i-1]);
                         break;
                     }
-                    auto ram = std::atoi(arg);
+                    auto ram = std::strtol(arg, nullptr, 0);
                     if (ram <= 0 || ram > 1024) {
                         std::fprintf(stderr, "Invalid value for parameter %s\nUsing 128KiB\n", argv[i-1]);
                         ram = 128*1024;
@@ -108,6 +112,18 @@ struct VmParamaters {
 
                     clock = clk * 1000;
 
+                } else if (strncmp(arg, "b", 1) == 0 ) {
+                    // A breakpoint
+                    i++;
+                    arg = argv[i];
+                    if (i >= argc || arg[0] == '-') {
+                        valid_params = false;
+                        std::fprintf(stderr, "Missing or invalid value for parameter %s\n", argv[i-1]);
+                        break;
+                    }
+                    vm::dword_t addr = std::strtol(arg, nullptr, 0);
+                    breaks.push_back(addr);
+
                 } else if (strncmp(arg, "h", 1) == 0 || strncmp(arg, "-help", 5) == 0) {
                     // Asked for help
                     std::printf("Virtual Computer toy Emulator\n\n");
@@ -119,6 +135,7 @@ struct VmParamaters {
                     std::printf("\t-c val or --cpu val : Sets the CPU to use, from \"tr3200\" or \"dcpu-16n\"\n");
                     std::printf("\t-m val or --disk val : How many RAM have the computer in KiB. Must be > 128 and < 1024. Will be round to a multiple of 128\n");
                     std::printf("\t--clock val : CPU clock speed in Khz. Must be 100, 250, 500 or 1000.\n");
+                    std::printf("\t-b val : Inserts a breakpoint at address val (could be hexadecimal or decimal).\n");
                     std::printf("\t-h or --help : Shows this help\n");
 
                     ask_help = true;
@@ -137,6 +154,7 @@ struct VmParamaters {
     CpuToUse cpu;                   //! CPU to use (default TR3200)
     unsigned clock = 100000;        //! CPU clock speed (default 100Khz)
 
+    std::vector<vm::dword_t> breaks;//" List of breakpoints
 
     bool valid_params = true;       //! Parsed correctly all parameters
     bool ask_help = false;          //! User asked by help

--- a/tools/include/VmParser.hpp
+++ b/tools/include/VmParser.hpp
@@ -23,9 +23,13 @@ enum class CpuToUse {
 struct VmParamaters {
 
     VmParamaters (const int argc, const char** argv) {
+        // Default values
         dsk_file = def_dsk_file;
         rom_file = nullptr;
 
+        cpu = CpuToUse::TR3200;
+
+        // Begin to parse
         for (int i = 1; i < argc; i++) {
             const char* arg = argv[i];
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -289,7 +289,7 @@ int main(int argc, char* argv[]) {
   auto floppy = std::make_shared<vm::dev::m5fdd::M35_Floppy>("disk.dsk");
   fd->insertFloppy(floppy);
 
-  vc.Reset();
+  vc.On();  // Powering it !
 
   std::cout << "Run program (r) or Step Mode (s) ?\n";
   char mode;
@@ -334,6 +334,11 @@ int main(int argc, char* argv[]) {
   bool loop = true;
   vm::cpu::TR3200State cpu_state;
 
+  // Delay here to enforce initial delta != 0
+  for (long i=0; i< 600000; i++) {
+    ;
+  }
+
   while ( loop) {
     // Calcs delta time
 
@@ -361,17 +366,19 @@ int main(int argc, char* argv[]) {
     }
 
     if (!debug) {
+      double ds = delta / 1000.0;
       ticks_count += ticks;
-      vc.Tick(ticks, delta / 1000.0 );
+      //vc.Tick(ticks, delta / 1000.0 );
+      ticks = vc.Update(ds);
       // NOTE This algorith is no-stable, as if the computer takes too time, will increase
       // the number of ticks forever, so we must put a top value to avoid these problem and
       // assume that we can runt at 100% of speed in these case.
-      ticks = (vm::BaseClock * delta  / 1000.0) + 0.5f; // Rounding bug in VS
-      if (ticks <= 3) {
-        ticks = 3;
-      } else if (ticks >= 80000) {
-        ticks = 80000;
-      }
+      //ticks = (vm::BaseClock * delta  / 1000.0) + 0.5f; // Rounding bug in VS
+      //if (ticks <= 3) {
+      //  ticks = 3;
+      //} else if (ticks >= 80000) {
+      //  ticks = 80000;
+      //}
 
     } else {
       ticks = vc.Step(delta / 1000.0 );

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -244,6 +244,13 @@ int main(int argc, char* argv[]) {
     std::printf("Floppy image file %s \n", options.dsk_file);
     fd->insertFloppy(floppy);
 
+    while (! options.breaks.empty()) {
+        auto brk = options.breaks.back();
+        options.breaks.pop_back();
+        vc.SetBreakPoint(brk);
+        std::printf("Inserting break point at 0x%06X\n", brk);
+    }
+
     vc.On();  // Powering it !
 
     std::cout << "Run program (r) or Step Mode (s) ?\n";
@@ -352,6 +359,12 @@ int main(int argc, char* argv[]) {
 
         } else {
             ticks = vc.Step(delta / 1000.0 );
+        }
+
+        if (vc.isBreaked()) { // Here is a breakpoint !
+            std::printf("\t\tBREAKPOINT\n\nSwithching to Step mode\n");
+            debug = true;
+            vc.Continue();
         }
 
 

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -329,13 +329,9 @@ int main(int argc, char* argv[]) {
         }
 #endif
 
-        if (debug) {
+        if (debug) { // Print PC and instruction BEFORE executing it
             vc.GetState((void*) &cpu_state, sizeof(cpu_state));
             print_pc(cpu_state, vc);
-            //if (vm.CPU().Skiping())
-            //  std::printf("Skiping!\n");
-            //if (vm.CPU().Sleeping())
-            //  std::printf("ZZZZzzzz...\n");
         }
 
         if (!debug) {
@@ -345,28 +341,17 @@ int main(int argc, char* argv[]) {
                 ds = 0.0000001;
             }
             ticks_count += ticks;
-            //vc.Tick(ticks, delta / 1000.0 );
             ticks = vc.Update(ds);
-            // NOTE This algorith is no-stable, as if the computer takes too time, will increase
-            // the number of ticks forever, so we must put a top value to avoid these problem and
-            // assume that we can runt at 100% of speed in these case.
-            //ticks = (vm::BaseClock * delta  / 1000.0) + 0.5f; // Rounding bug in VS
-            //if (ticks <= 3) {
-            //  ticks = 3;
-            //} else if (ticks >= 80000) {
-            //  ticks = 80000;
-            //}
 
         } else {
             ticks = vc.Step(delta / 1000.0 );
         }
 
         if (vc.isBreaked()) { // Here is a breakpoint !
-            std::printf("\t\tBREAKPOINT\n\nSwithching to Step mode\n");
+            std::printf("\t\tBREAKPOINT\n\nSwithching to Step mode\n\n");
             debug = true;
             vc.Continue();
         }
-
 
         // Speed info
         if (!debug && ticks_count > 400000) {
@@ -386,9 +371,25 @@ int main(int argc, char* argv[]) {
             std::printf("Takes %u cycles\n", cpu_cycles);
             print_regs(cpu_state);
             //print_stack(vm.CPU(), vm.RAM());
-            c = std::getchar();
-            if (c == 'q' || c == 'Q')
-                loop = false;
+
+            while (1) { // Parse "command"
+                c = std::getchar();
+
+                if (c == 'q' || c == 'Q') {
+                    loop = false;
+                    break;
+                }
+
+                if (c == 'r' || c == 'R') {
+                    debug = false;
+                    break;
+                }
+
+                if (c == 's' || c == 'S' || c =='\n') {
+                    debug = true;
+                    break;
+                }
+            }
 
         }
 #ifdef GLFW3_ENABLE

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -318,7 +318,11 @@ int main(int argc, char* argv[]) {
 
         auto oldClock = clock;
         clock = high_resolution_clock::now();
-        delta = duration_cast<milliseconds>(clock - oldClock).count();
+        if (!debug) { // Calc delta
+            delta = duration_cast<milliseconds>(clock - oldClock).count();
+        } else {
+            delta = 0.04;
+        }
 
 
 
@@ -351,6 +355,9 @@ int main(int argc, char* argv[]) {
             std::printf("\t\tBREAKPOINT\n\nSwithching to Step mode\n\n");
             debug = true;
             vc.Continue();
+
+            vc.GetState((void*) &cpu_state, sizeof(cpu_state));
+            print_pc(cpu_state, vc);
         }
 
         // Speed info
@@ -394,9 +401,6 @@ int main(int argc, char* argv[]) {
         }
 #ifdef GLFW3_ENABLE
         gl.UpdScreen (glfwos, delta / 1000.0);
-        if (debug) {
-            gl.Halted();
-        }
 #endif
 
     }

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -394,6 +394,9 @@ int main(int argc, char* argv[]) {
         }
 #ifdef GLFW3_ENABLE
         gl.UpdScreen (glfwos, delta / 1000.0);
+        if (debug) {
+            gl.Halted();
+        }
 #endif
 
     }

--- a/tools/main.cpp
+++ b/tools/main.cpp
@@ -1,8 +1,14 @@
-/**
- * Trillek Virtual Computer - main.cpp
+/*!
+ * \brief       Test/Toy emulator
+ * \file        main.cpp
+ * \copyright   The MIT License (MIT)
+ *
  * Test/Toy executable that uses the Virtual Computer lib to run a emulation
  */
+
 #include "OS.hpp"
+
+#include "GlEngine.hpp"
 
 #include "VC.hpp"
 #include "devices/DummyDevice.hpp"
@@ -25,211 +31,149 @@
 
 #ifdef GLFW3_ENABLE
 
-unsigned winWidth;
-unsigned winHeight;
-
-//bool capture_keyboard = false;
-
-GLuint screenTex; // ID of screen Texture
-GLuint tex_pbo;   // ID of the screen texture PBO
-
-// Handler of shader program
-GLuint shaderProgram;
-
-// Ptrs to source doe of shaders
-GLchar *vertexSource = nullptr;
-GLchar *fragmentSource = nullptr;
-
-// Handlers of the shader programs
-GLuint vertexShader, fragmentShader;
-
-// Handles for uniform inputs to the shader
-GLuint modelId;
-GLuint viewId;
-GLuint projId;
-GLuint timeId;
-
-const unsigned int sh_in_Position = 0;
-const unsigned int sh_in_Color = 1;
-const unsigned int sh_in_UV = 3;
-
-static const GLfloat N_VERTICES=4;
-GLuint vertexbuffer;
-static const float vdata[] = {
-  3.2,  2.4, 0.0, // Top Right
-  -3.2,  2.4, 0.0, // Top Left
-  3.2, -2.4, 0.0, // Botton Right
-  -3.2, -2.4, 0.0, // Bottom Left
-};
-
-GLuint colorbuffer;
-static const float color_data[] = {
-  1.0,  1.0, 1.0, // Top Right
-  1.0,  1.0, 1.0, // Top Left
-  1.0,  1.0, 1.0, // Botton Right
-  1.0,  1.0, 1.0, // Bottom Left
-};
-
-GLuint uvbuffer;
-static const float uv_data[] = {
-  1.0,  0.0,      // Top Right
-  0.0,  0.0,      // Top Left
-  1.0,  1.0,      // Botton Right
-  0.0,  1.0,      // Bottom Left
-};
-
-glm::mat4 proj, view, model; // MVP Matrixes
-float yaw  = 0.0;
-float pith = 0.0;
-float zoom = 6.0;
-
-void initGL(OS::OS& os);
-
-//void updatePBO (vm::cda::CDA*);
-
 class KeyEventHandler : public OS::event::IKeyboardEventHandler {
-public:
-  KeyEventHandler () : OS::event::IKeyboardEventHandler(),
-    prev_key(vm::dev::gkeyboard::SCANCODES::SCAN_NULL),
-    mod (vm::dev::gkeyboard::KEY_MODS::MOD_NONE) {
-    // Register listened characters
-    for (unsigned c = 0x20; c <= 0x7E; c++){
-      this->chars.push_back(c);
-    }
-    for (unsigned c = 0xA0; c <= 0xFF; c++){
-      this->chars.push_back(c);
-    }
-    this->chars.push_back(0x08); // Backspace
-    this->chars.push_back(0x09); // Tabulator
-    this->chars.push_back(0x0D); // Return
-    this->chars.push_back(0x1B); // Escape
-    this->chars.push_back(0x7F); // Delete (need translation)
+    public:
+        KeyEventHandler () : OS::event::IKeyboardEventHandler(),
+        prev_key(vm::dev::gkeyboard::SCANCODES::SCAN_NULL),
+        mod (vm::dev::gkeyboard::KEY_MODS::MOD_NONE) {
+            // Register listened characters
+            for (unsigned c = 0x20; c <= 0x7E; c++){
+                this->chars.push_back(c);
+            }
+            for (unsigned c = 0xA0; c <= 0xFF; c++){
+                this->chars.push_back(c);
+            }
+            this->chars.push_back(0x08); // Backspace
+            this->chars.push_back(0x09); // Tabulator
+            this->chars.push_back(0x0D); // Return
+            this->chars.push_back(0x1B); // Escape
+            this->chars.push_back(0x7F); // Delete (need translation)
 
-    // Register listened keys.
-    for (unsigned i = 32; i <= 265 ; i++) {
-      this->keys.push_back(i);
-    }
+            // Register listened keys.
+            for (unsigned i = 32; i <= 265 ; i++) {
+                this->keys.push_back(i);
+            }
 
-    this->keys.push_back(340);
-    this->keys.push_back(341);
-    this->keys.push_back(342);
-    this->keys.push_back(344);
-    this->keys.push_back(345);
-    this->keys.push_back(346);
-  }
+            this->keys.push_back(340);
+            this->keys.push_back(341);
+            this->keys.push_back(342);
+            this->keys.push_back(344);
+            this->keys.push_back(345);
+            this->keys.push_back(346);
+        }
 
-  // Called when on the keys reported during register has a state change.
-  void KeyStateChange(const unsigned int key, const OS::event::KEY_STATE state) {
-    using namespace vm::dev::gkeyboard;
-    if (state == OS::event::KEY_STATE::KS_DOWN) {
-      prev_key = key & 0xFFFF; // Stores the "scancode"
+        // Called when on the keys reported during register has a state change.
+        void KeyStateChange(const unsigned int key, const OS::event::KEY_STATE state) {
+            using namespace vm::dev::gkeyboard;
+            if (state == OS::event::KEY_STATE::KS_DOWN) {
+                prev_key = key & 0xFFFF; // Stores the "scancode"
 
-      std::printf("Scancode : 0x%04X\n", prev_key);
+                std::printf("Scancode : 0x%04X\n", prev_key);
 
-      // TODO Use a general if and a lookup table
-      switch (prev_key) { // Special cases that not are catch by character events
-        case GLFW_KEY_ESCAPE :
-          gk->EnforceSendKeyEvent(prev_key, KEY_ESC, mod);
-          break;
+                // TODO Use a general if and a lookup table
+                switch (prev_key) { // Special cases that not are catch by character events
+                    case GLFW_KEY_ESCAPE :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_ESC, mod);
+                        break;
 
-        case GLFW_KEY_ENTER :
-          gk->EnforceSendKeyEvent(prev_key, KEY_RETURN, mod);
-          break;
+                    case GLFW_KEY_ENTER :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_RETURN, mod);
+                        break;
 
-        case GLFW_KEY_TAB :
-          gk->EnforceSendKeyEvent(prev_key, KEY_TAB, mod);
-          break;
+                    case GLFW_KEY_TAB :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_TAB, mod);
+                        break;
 
-        case GLFW_KEY_BACKSPACE :
-          gk->EnforceSendKeyEvent(prev_key, KEY_BACKSPACE, mod);
-          break;
+                    case GLFW_KEY_BACKSPACE :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_BACKSPACE, mod);
+                        break;
 
-        case GLFW_KEY_INSERT :
-          gk->EnforceSendKeyEvent(prev_key, KEY_INSERT, mod);
-          break;
+                    case GLFW_KEY_INSERT :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_INSERT, mod);
+                        break;
 
-        case GLFW_KEY_DELETE :
-          gk->EnforceSendKeyEvent(prev_key, KEY_DELETE, mod);
-          break;
+                    case GLFW_KEY_DELETE :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_DELETE, mod);
+                        break;
 
-        case GLFW_KEY_RIGHT :
-          gk->EnforceSendKeyEvent(prev_key, KEY_ARROW_RIGHT, mod);
-          break;
+                    case GLFW_KEY_RIGHT :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_ARROW_RIGHT, mod);
+                        break;
 
-        case GLFW_KEY_LEFT :
-          gk->EnforceSendKeyEvent(prev_key, KEY_ARROW_LEFT, mod);
-          break;
+                    case GLFW_KEY_LEFT :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_ARROW_LEFT, mod);
+                        break;
 
-        case GLFW_KEY_DOWN :
-          gk->EnforceSendKeyEvent(prev_key, KEY_ARROW_DOWN, mod);
-          break;
+                    case GLFW_KEY_DOWN :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_ARROW_DOWN, mod);
+                        break;
 
-        case GLFW_KEY_UP :
-          gk->EnforceSendKeyEvent(prev_key, KEY_ARROW_UP, mod);
-          break;
+                    case GLFW_KEY_UP :
+                        gk->EnforceSendKeyEvent(prev_key, KEY_ARROW_UP, mod);
+                        break;
 
-        case GLFW_KEY_LEFT_SHIFT:
-        case GLFW_KEY_RIGHT_SHIFT:
-          gk->EnforceSendKeyEvent(prev_key, KEY_SHIFT, mod);
-          mod |= KEY_MODS::MOD_SHIFT;
-          break;
+                    case GLFW_KEY_LEFT_SHIFT:
+                    case GLFW_KEY_RIGHT_SHIFT:
+                        gk->EnforceSendKeyEvent(prev_key, KEY_SHIFT, mod);
+                        mod |= KEY_MODS::MOD_SHIFT;
+                        break;
 
-        case GLFW_KEY_LEFT_CONTROL:
-        case GLFW_KEY_RIGHT_CONTROL:
-          gk->EnforceSendKeyEvent(prev_key, KEY_CONTROL, mod);
-          mod |= KEY_MODS::MOD_CTRL;
-          break;
+                    case GLFW_KEY_LEFT_CONTROL:
+                    case GLFW_KEY_RIGHT_CONTROL:
+                        gk->EnforceSendKeyEvent(prev_key, KEY_CONTROL, mod);
+                        mod |= KEY_MODS::MOD_CTRL;
+                        break;
 
-        case GLFW_KEY_LEFT_ALT:
-        case GLFW_KEY_RIGHT_ALT:
-          gk->EnforceSendKeyEvent(prev_key, KEY_ALT, mod);
-          mod |= KEY_MODS::MOD_ALTGR;
-          break;
+                    case GLFW_KEY_LEFT_ALT:
+                    case GLFW_KEY_RIGHT_ALT:
+                        gk->EnforceSendKeyEvent(prev_key, KEY_ALT, mod);
+                        mod |= KEY_MODS::MOD_ALTGR;
+                        break;
 
-        default:
-          return;
-      }
+                    default:
+                        return;
+                }
 
-    } else {
-      switch (key) {
-        case GLFW_KEY_LEFT_SHIFT:
-        case GLFW_KEY_RIGHT_SHIFT:
-          mod &= (KEY_MODS::MOD_SHIFT ^ 0xFFFF);
-          break;
+            } else {
+                switch (key) {
+                    case GLFW_KEY_LEFT_SHIFT:
+                    case GLFW_KEY_RIGHT_SHIFT:
+                        mod &= (KEY_MODS::MOD_SHIFT ^ 0xFFFF);
+                        break;
 
-        case GLFW_KEY_LEFT_CONTROL:
-        case GLFW_KEY_RIGHT_CONTROL:
-          mod &= (KEY_MODS::MOD_CTRL ^ 0xFFFF);
-          break;
+                    case GLFW_KEY_LEFT_CONTROL:
+                    case GLFW_KEY_RIGHT_CONTROL:
+                        mod &= (KEY_MODS::MOD_CTRL ^ 0xFFFF);
+                        break;
 
-        case GLFW_KEY_LEFT_ALT:
-        case GLFW_KEY_RIGHT_ALT:
-          mod &= (KEY_MODS::MOD_ALTGR ^ 0xFFFF);
-          break;
+                    case GLFW_KEY_LEFT_ALT:
+                    case GLFW_KEY_RIGHT_ALT:
+                        mod &= (KEY_MODS::MOD_ALTGR ^ 0xFFFF);
+                        break;
 
-        default:
-          return;
-      }
-    }
-  }
+                    default:
+                        return;
+                }
+            }
+        }
 
-  void CharDown(const unsigned int c) {
-    unsigned chr = c;
-    if (gk) {
-      if (chr == 0x7F) {
-        chr = vm::dev::gkeyboard::KEY_DELETE;
-      }
+        void CharDown(const unsigned int c) {
+            unsigned chr = c;
+            if (gk) {
+                if (chr == 0x7F) {
+                    chr = vm::dev::gkeyboard::KEY_DELETE;
+                }
 
-      //std::printf("Character %u='%c' mod=%u -> nº events stored : ", chr, chr, mod);
-      vm::dword_t scancode = prev_key & 0xFFFF;
-      gk->EnforceSendKeyEvent(scancode, c & 0xFF, mod);
-      //std::printf("%u \n", gk->E());
-    }
-  }
+                //std::printf("Character %u='%c' mod=%u -> nº events stored : ", chr, chr, mod);
+                vm::dword_t scancode = prev_key & 0xFFFF;
+                gk->EnforceSendKeyEvent(scancode, c & 0xFF, mod);
+                //std::printf("%u \n", gk->E());
+            }
+        }
 
-  std::shared_ptr<vm::dev::gkeyboard::GKeyboardDev> gk;
-  unsigned int prev_key;
-  vm::word_t mod;
+        std::shared_ptr<vm::dev::gkeyboard::GKeyboardDev> gk;
+        unsigned int prev_key;
+        vm::word_t mod;
 };
 
 #endif
@@ -239,292 +183,205 @@ void print_pc(const vm::cpu::TR3200State& state, const vm::VComputer& vc);
 //void print_stack(const vm::cpu::TR3200& cpu, const vm::ram::Mem& ram);
 
 int main(int argc, char* argv[]) {
-  using namespace vm;
-  using namespace vm::cpu;
+    using namespace vm;
+    using namespace vm::cpu;
 
-  byte_t* rom = nullptr;
-  size_t rom_size = 0;
+    byte_t* rom = nullptr;
+    size_t rom_size = 0;
 
-  if (argc < 2) {
-    std::printf("Usage: %s binary_file\n", argv[0]);
-    return -1;
-
-  } else {
-    rom = new byte_t[32*1024];
-
-    std::printf("Opening file %s\n", argv[1]);
-
-    int size = vm::aux::LoadROM(argv[1], rom);
-    if (size < 0) {
-      std::fprintf(stderr, "An error occurred while reading file %s\n", argv[1]);
-      return -1;
-    }
-
-    std::printf("Read %d bytes and stored in ROM\n", size);
-    rom_size = size;
-  }
-
-  // Create the Virtual Machine
-  VComputer vc;
-  std::unique_ptr<vm::cpu::TR3200> cpu(new TR3200());
-  cpu->Clock();
-  vc.SetCPU(std::move(cpu));
-
-  vc.SetROM(rom, rom_size);
-
-  // Add devices to tue Virtual Machine
-  auto gcard = std::make_shared<vm::dev::tda::TDADev>();
-  vm::dev::tda::TDAScreen gcard_screen = {0};
-  vc.AddDevice(5, gcard);
-
-  auto gk = std::make_shared<vm::dev::gkeyboard::GKeyboardDev>();
-  vc.AddDevice(4, gk);
-
-  auto ddev = std::make_shared<vm::DummyDevice>();
-  vc.AddDevice(10, ddev);
-
-  // Floppy drive
-  auto fd = std::make_shared<vm::dev::m5fdd::M35FD>();
-  vc.AddDevice(6, fd);
-  auto floppy = std::make_shared<vm::dev::m5fdd::M35_Floppy>("disk.dsk");
-  fd->insertFloppy(floppy);
-
-  vc.On();  // Powering it !
-
-  std::cout << "Run program (r) or Step Mode (s) ?\n";
-  char mode;
-  std::cin >> mode;
-  std::getchar();
-
-
-  bool debug = false;
-  if (mode == 's' || mode == 'S') {
-    debug = true;
-  }
-
-
-
-#ifdef GLFW3_ENABLE
-  OS::OS glfwos;
-  if (!glfwos.InitializeWindow(1024, 768, "Trillek Virtual Computer demo emulator")) {
-    std::clog << "Failed creating the window or context.";
-    return -1;
-  }
-
-  initGL(glfwos);
-  std::printf("Initiated OpenGL\n");
-  float frame_count = 0; // Count frames
-
-  KeyEventHandler keyhandler;
-  keyhandler.gk = gk;
-  glfwos.RegisterKeyboardEventHandler(&keyhandler);
-
-#endif
-
-  std::cout << "Running!\n";
-  unsigned ticks = 16050;
-  unsigned long ticks_count = 0;
-
-  using namespace std::chrono;
-  auto clock = high_resolution_clock::now();
-  double delta; // Time delta in seconds
-  double t_acu = 0; // Acumulated time
-
-  int c = ' ';
-  bool loop = true;
-  vm::cpu::TR3200State cpu_state;
-
-  // Delay here to enforce initial delta != 0
-  for (long i=0; i< 600000; i++) {
-    ;
-  }
-
-  while ( loop) {
-    // Calcs delta time
-
-    auto oldClock = clock;
-    clock = high_resolution_clock::now();
-    delta = duration_cast<milliseconds>(clock - oldClock).count();
-
-    t_acu += delta/1000.0;
-
-
-#ifdef GLFW3_ENABLE
-    if (glfwos.Closing()) {
-      loop = false;
-      continue;
-    }
-#endif
-
-    if (debug) {
-      vc.GetState((void*) &cpu_state, sizeof(cpu_state));
-      print_pc(cpu_state, vc);
-      //if (vm.CPU().Skiping())
-      //  std::printf("Skiping!\n");
-      //if (vm.CPU().Sleeping())
-      //  std::printf("ZZZZzzzz...\n");
-    }
-
-    if (!debug) {
-      double ds = delta / 1000.0;
-      ticks_count += ticks;
-      //vc.Tick(ticks, delta / 1000.0 );
-      ticks = vc.Update(ds);
-      // NOTE This algorith is no-stable, as if the computer takes too time, will increase
-      // the number of ticks forever, so we must put a top value to avoid these problem and
-      // assume that we can runt at 100% of speed in these case.
-      //ticks = (vm::BaseClock * delta  / 1000.0) + 0.5f; // Rounding bug in VS
-      //if (ticks <= 3) {
-      //  ticks = 3;
-      //} else if (ticks >= 80000) {
-      //  ticks = 80000;
-      //}
+    // TODO Write a paramater parser
+    if (argc < 2) {
+        std::printf("Usage: %s binary_file\n", argv[0]);
+        return -1;
 
     } else {
-      ticks = vc.Step(delta / 1000.0 );
+        rom = new byte_t[32*1024];
+
+        std::printf("Opening file %s\n", argv[1]);
+
+        int size = vm::aux::LoadROM(argv[1], rom);
+        if (size < 0) {
+            std::fprintf(stderr, "An error occurred while reading file %s\n", argv[1]);
+            return -1;
+        }
+
+        std::printf("Read %d bytes and stored in ROM\n", size);
+        rom_size = size;
+    }
+
+    // Create the Virtual Machine
+    VComputer vc;
+    std::unique_ptr<vm::cpu::TR3200> cpu(new TR3200());
+    cpu->Clock();
+    vc.SetCPU(std::move(cpu));
+
+    vc.SetROM(rom, rom_size);
+
+    // Add devices to tue Virtual Machine
+    auto gcard = std::make_shared<vm::dev::tda::TDADev>();
+    vm::dev::tda::TDAScreen gcard_screen = {0};
+    vc.AddDevice(5, gcard);
+
+    auto gk = std::make_shared<vm::dev::gkeyboard::GKeyboardDev>();
+    vc.AddDevice(4, gk);
+
+    auto ddev = std::make_shared<vm::DummyDevice>();
+    vc.AddDevice(10, ddev);
+
+    // Floppy drive
+    auto fd = std::make_shared<vm::dev::m5fdd::M35FD>();
+    vc.AddDevice(6, fd);
+    auto floppy = std::make_shared<vm::dev::m5fdd::M35_Floppy>("disk.dsk");
+    fd->insertFloppy(floppy);
+
+    vc.On();  // Powering it !
+
+    std::cout << "Run program (r) or Step Mode (s) ?\n";
+    char mode;
+    std::cin >> mode;
+    std::getchar();
+
+
+    bool debug = false;
+    if (mode == 's' || mode == 'S') {
+        debug = true;
     }
 
 
-    // Speed info
-    if (!debug && ticks_count > 400000) {
-      std::printf("Running %u cycles in %f ms ", ticks, delta);
-      double ttick = delta / ticks;
-      double tclk = 1000.0 / 1000000.0; // Base clock 1Mhz
-      std::printf("Ttick %f ms ", ttick);
-      std::printf("Tclk %f ms ", tclk);
-      std::printf("Speed of %f %% \n", 100.0f * (tclk / ttick) );
-      ticks_count -= 400000;
+
+#ifdef GLFW3_ENABLE
+    GlEngine gl;
+    OS::OS glfwos;
+    if (!glfwos.InitializeWindow(1024, 768, "Trillek Virtual Computer demo emulator")) {
+        std::clog << "Failed creating the window or context.";
+        return -1;
     }
 
+    if (gl.initGL(glfwos) != 0) {
+        std::cerr << "Error initiating OpenGL\n";
+        return -1;
+    }
 
-    if (debug) {
-      vc.GetState((void*) &cpu_state, sizeof(cpu_state));
-      auto cpu_cycles = ticks / 10; // TODO Cahnge this to calc it base on CPU Clock speed
-      std::printf("Takes %u cycles\n", cpu_cycles);
-      print_regs(cpu_state);
-      //print_stack(vm.CPU(), vm.RAM());
-      c = std::getchar();
-      if (c == 'q' || c == 'Q')
-        loop = false;
+    std::printf("Initiated OpenGL\n");
+
+    KeyEventHandler keyhandler;
+    keyhandler.gk = gk;
+    glfwos.RegisterKeyboardEventHandler(&keyhandler);
+
+    gl.SetTextureCB ([&gcard, &gcard_screen] (void* tdata) {
+        // Update Texture callback
+        gcard->DumpScreen (gcard_screen);
+        gcard->DoVSync();
+
+        vm::dword_t* tex = (vm::dword_t*)tdata;
+        TDAtoRGBATexture(gcard_screen, tex); // Write the texture to the PBO buffer
+    });
+
+#endif
+
+    std::cout << "Running!\n";
+    unsigned ticks = 16050;
+    unsigned long ticks_count = 0;
+
+    using namespace std::chrono;
+    auto clock = high_resolution_clock::now();
+    double delta; // Time delta in seconds
+
+    int c = ' ';
+    bool loop = true;
+    vm::cpu::TR3200State cpu_state;
+
+    // Delay here to enforce initial delta != 0
+    for (long i=0; i< 600000; i++) {
+        ;
+    }
+
+    while ( loop) {
+        // Calcs delta time
+
+        auto oldClock = clock;
+        clock = high_resolution_clock::now();
+        delta = duration_cast<milliseconds>(clock - oldClock).count();
+
+
+
+#ifdef GLFW3_ENABLE
+        if (glfwos.Closing()) {
+            loop = false;
+            continue;
+        }
+#endif
+
+        if (debug) {
+            vc.GetState((void*) &cpu_state, sizeof(cpu_state));
+            print_pc(cpu_state, vc);
+            //if (vm.CPU().Skiping())
+            //  std::printf("Skiping!\n");
+            //if (vm.CPU().Sleeping())
+            //  std::printf("ZZZZzzzz...\n");
+        }
+
+        if (!debug) {
+            double ds = delta / 1000.0;
+            if (ds == 0) {
+                std::fprintf(stderr, "Wops! ds is 0 seconds !!!\t delta = %f\n", delta);
+                ds = 0.0000001;
+            }
+            ticks_count += ticks;
+            //vc.Tick(ticks, delta / 1000.0 );
+            ticks = vc.Update(ds);
+            // NOTE This algorith is no-stable, as if the computer takes too time, will increase
+            // the number of ticks forever, so we must put a top value to avoid these problem and
+            // assume that we can runt at 100% of speed in these case.
+            //ticks = (vm::BaseClock * delta  / 1000.0) + 0.5f; // Rounding bug in VS
+            //if (ticks <= 3) {
+            //  ticks = 3;
+            //} else if (ticks >= 80000) {
+            //  ticks = 80000;
+            //}
+
+        } else {
+            ticks = vc.Step(delta / 1000.0 );
+        }
+
+
+        // Speed info
+        if (!debug && ticks_count > 400000) {
+            std::printf("Running %u cycles in %f ms ", ticks, delta);
+            double ttick = delta / ticks;
+            double tclk = 1000.0 / 1000000.0; // Base clock 1Mhz
+            std::printf("Ttick %f ms ", ttick);
+            std::printf("Tclk %f ms ", tclk);
+            std::printf("Speed of %f %% \n", 100.0f * (tclk / ttick) );
+            ticks_count -= 400000;
+        }
+
+
+        if (debug) {
+            vc.GetState((void*) &cpu_state, sizeof(cpu_state));
+            auto cpu_cycles = ticks / 10; // TODO Cahnge this to calc it base on CPU Clock speed
+            std::printf("Takes %u cycles\n", cpu_cycles);
+            print_regs(cpu_state);
+            //print_stack(vm.CPU(), vm.RAM());
+            c = std::getchar();
+            if (c == 'q' || c == 'Q')
+                loop = false;
+
+        }
+#ifdef GLFW3_ENABLE
+        gl.UpdScreen (glfwos, delta / 1000.0);
+#endif
 
     }
 
 #ifdef GLFW3_ENABLE
-    // Clear The Screen And The Depth Buffer
-    frame_count += 1.0;
+    glfwos.Terminate();
+#endif
 
-    glClearColor( 0.1f, 0.1f, 0.1f, 1.0f );
-    glClear( GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-
-    // Model matrix <- Identity
-    model = glm::mat4(1.0f);
-
-    // Camera Matrix
-    view = glm::lookAt(
-        glm::vec3(
-          (float)(zoom * sin(yaw)*cos(pith)),
-          (float)(zoom * sin(pith)),
-          (float)(zoom * cos(yaw))*cos(pith)), // Were is the camera
-        glm::vec3(0,0,0), // and looks at the origin
-        glm::vec3(0,1,0)  // Head is up (set to 0,-1,0 to look upside-down)
-        );
-
-    // Drawing ...
-    glUseProgram(shaderProgram);
-    // Set sampler to user Texture Unit 0
-    glUniform1i(glGetUniformLocation( shaderProgram, "texture0" ), 0);
-
-    // Bind texture
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, screenTex);
-
-    if (t_acu >= 0.04) { // Updates screen texture at a rate of ~25 Hz
-      t_acu -= 0.04;
-      // Dump a copy of the CDA card state
-      gcard->DumpScreen (gcard_screen);
-      gcard->DoVSync();
-
-      // Stream the texture *************************************************
-      glBindBuffer(GL_PIXEL_UNPACK_BUFFER, tex_pbo);
-
-      // Copy the PBO to the texture
-      glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 320, 240, GL_RGBA, GL_UNSIGNED_BYTE, 0);
-
-      // Updates the PBO with the new texture
-      auto tdata = (dword_t*) glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
-      if (tdata != nullptr) {
-        //std::fill_n(tdata, 320*240, 0xFF800000);
-        TDAtoRGBATexture(gcard_screen, tdata); // Write the texture to the PBO buffer
-
-        glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
-      }
-
-      glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0); // Release the PBO
+    if (rom != nullptr) {
+        delete[] rom;
     }
-
-    // Enable attribute in_Position as being used
-    glEnableVertexAttribArray(sh_in_Position);
-    glBindBuffer(GL_ARRAY_BUFFER, vertexbuffer);
-    // Vertex data to attribute index 0 (shadderAttribute) and is 3 floats
-    glVertexAttribPointer(
-        sh_in_Position,
-        3,
-        GL_FLOAT,
-        GL_FALSE,
-        0,
-        0 );
-
-    // Enable attribute in_Color as being used
-    glEnableVertexAttribArray(sh_in_Color);
-    glBindBuffer(GL_ARRAY_BUFFER, colorbuffer);
-    // Vertex data to attribute index 0 (shadderAttribute) and is 3 floats
-    glVertexAttribPointer(
-        sh_in_Color,
-        3,
-        GL_FLOAT,
-        GL_FALSE,
-        0,
-        0 );
-
-    // Enable attribute in_UV as being used
-    glEnableVertexAttribArray(sh_in_UV);
-    glBindBuffer(GL_ARRAY_BUFFER, uvbuffer);
-    // Vertex data to attribute index 0 (shadderAttribute) and is 3 floats
-    glVertexAttribPointer(
-        sh_in_UV,
-        2,
-        GL_FLOAT,
-        GL_FALSE,
-        0,
-        0 );
-
-    // Send M, V, P matrixes to the uniform inputs,
-    glUniformMatrix4fv(modelId, 1, GL_FALSE, &model[0][0]);
-    glUniformMatrix4fv(viewId, 1, GL_FALSE, &view[0][0]);
-    glUniformMatrix4fv(projId, 1, GL_FALSE, &proj[0][0]);
-
-    glUniform1f(timeId, (float)((int)frame_count +1));
-
-    glDrawArrays(GL_TRIANGLE_STRIP, sh_in_Position, N_VERTICES);
-
-    glDisableVertexAttribArray(sh_in_Position);
-    glDisableVertexAttribArray(sh_in_Color);
-    glDisableVertexAttribArray(sh_in_UV);
-
-    // Update host window
-    glfwos.SwapBuffers();
-    glfwos.OSMessageLoop();
-#endif
-  }
-
-#ifdef GLFW3_ENABLE
-  glfwos.Terminate();
-#endif
-
-  if (rom != nullptr) {
-    delete[] rom;
-  }
-  return 0;
+    return 0;
 }
 
 // Alias to special registers
@@ -566,240 +423,48 @@ int main(int argc, char* argv[]) {
 #define FLAGS   r[REG_FLAGS]
 
 void print_regs(const vm::cpu::TR3200State& state) {
-  // Print registers
+    // Print registers
 
-  for (int i=0; i < 11; i++) {
-    std::printf("%%r%2d= 0x%08X ", i, state.r[i]);
-    if (i == 3 || i == 7 || i == 11 || i == 15 || i == 19 || i == 23 || i == 27 || i == 31)
-      std::printf("\n");
-  }
-  std::printf("%%y= 0x%08X\n", state.r[REG_Y]);
+    for (int i=0; i < 11; i++) {
+        std::printf("%%r%2d= 0x%08X ", i, state.r[i]);
+        if (i == 3 || i == 7 || i == 11 || i == 15 || i == 19 || i == 23 || i == 27 || i == 31)
+            std::printf("\n");
+    }
+    std::printf("%%y= 0x%08X\n", state.r[REG_Y]);
 
-  std::printf("%%ia= 0x%08X ", state.r[REG_IA]);
-  auto flags = state.r[REG_FLAGS];
-  std::printf("%%flags= 0x%08X ", flags);
-  std::printf("%%bp= 0x%08X ",  state.r[BP]);
-  std::printf("%%sp= 0x%08X\n", state.r[SP]);
+    std::printf("%%ia= 0x%08X ", state.r[REG_IA]);
+    auto flags = state.r[REG_FLAGS];
+    std::printf("%%flags= 0x%08X ", flags);
+    std::printf("%%bp= 0x%08X ",  state.r[BP]);
+    std::printf("%%sp= 0x%08X\n", state.r[SP]);
 
-  std::printf("%%pc= 0x%08X \n", state.pc);
-  std::printf("ESS: %d EI: %d \t IF: %d DE %d OF: %d CF: %d\n",
-      GET_ESS(flags), GET_EI(flags), GET_IF(flags) , GET_DE(flags) , GET_OF(flags) , GET_CF(flags));
-  std::printf("\n");
+    std::printf("%%pc= 0x%08X \n", state.pc);
+    std::printf("ESS: %d EI: %d \t IF: %d DE %d OF: %d CF: %d\n",
+            GET_ESS(flags), GET_EI(flags), GET_IF(flags) , GET_DE(flags) , GET_OF(flags) , GET_CF(flags));
+    std::printf("\n");
 
 }
 
 void print_pc(const vm::cpu::TR3200State& state, const vm::VComputer& vc) {
-  vm::dword_t val = vc.ReadDW(state.pc);
+    vm::dword_t val = vc.ReadDW(state.pc);
 
-  std::printf("\tPC : 0x%08X > 0x%08X ", state.pc, val);
-  std::cout << vm::cpu::DisassemblyTR3200(vc,  state.pc) << std::endl;
+    std::printf("\tPC : 0x%08X > 0x%08X ", state.pc, val);
+    std::cout << vm::cpu::DisassemblyTR3200(vc,  state.pc) << std::endl;
 }
 
 /*
-void print_stack(const vm::cpu::TR3200& cpu, const vm::ram::Mem& ram) {
-  std::printf("STACK:\n");
+   void print_stack(const vm::cpu::TR3200& cpu, const vm::ram::Mem& ram) {
+   std::printf("STACK:\n");
 
-  for (size_t i =0; i <5*4; i +=4) {
-    auto val = ram.RD(cpu.Reg(SP)+ i);
+   for (size_t i =0; i <5*4; i +=4) {
+   auto val = ram.RD(cpu.Reg(SP)+ i);
 
-    std::printf("0x%08X\n", val);
-    if (((size_t)(cpu.Reg(SP)) + i) >= 0xFFFFFFFF)
-      break;
-  }
-}
-*/
+   std::printf("0x%08X\n", val);
+   if (((size_t)(cpu.Reg(SP)) + i) >= 0xFFFFFFFF)
+   break;
+   }
+   }
+   */
 
-#ifdef GLFW3_ENABLE
-
-
-// Init OpenGL ************************************************************
-void initGL(OS::OS& os) {
-  int OpenGLVersion[2];
-
-  // Use the GL3 way to get the version number
-  glGetIntegerv(GL_MAJOR_VERSION, &OpenGLVersion[0]);
-  glGetIntegerv(GL_MINOR_VERSION, &OpenGLVersion[1]);
-  std::cout << "OpenGL " << OpenGLVersion[0] << "." << OpenGLVersion[1] << "\n";
-
-  // Sanity check to make sure we are at least in a good major version number.
-  assert((OpenGLVersion[0] > 1) && (OpenGLVersion[0] < 5));
-
-  winWidth = os.GetWindowWidth(); winHeight = os.GetWindowHeight();
-
-  // Determine the aspect ratio and sanity check it to a safe ratio
-  GLfloat aspectRatio = static_cast<float>(winWidth) / static_cast<float>(winHeight);
-  if (aspectRatio < 1.0f) {
-    aspectRatio = 4.0f / 3.0f;
-  }
-  // Projection matrix : 45° Field of View
-  proj = glm::perspective(
-      45.0f,      // FOV
-      aspectRatio,
-      0.1f,       // Near cliping plane
-      10000.0f);  // Far cliping plane
-
-  glPolygonMode( GL_FRONT_AND_BACK, GL_FILL );
-  #if __APPLE__
-    // GL_MULTISAMPLE are Core.
-    glEnable(GL_MULTISAMPLE);
-  #else
-    if (GLEW_ARB_multisample) {
-      glEnable(GL_MULTISAMPLE_ARB);
-    }
-  #endif
-  glEnable(GL_CULL_FACE);
-  glCullFace(GL_BACK);
-
-  glEnable(GL_DEPTH_TEST);
-  // Accept fragment if it closer to the camera than the former one
-  glDepthFunc(GL_LESS);
-
-
-  // Initialize VBOs ********************************************************
-  glGenBuffers(1, &vertexbuffer);
-  glBindBuffer(GL_ARRAY_BUFFER, vertexbuffer);
-  // Upload data to VBO
-  glBufferData(GL_ARRAY_BUFFER, sizeof(vdata), vdata, GL_STATIC_DRAW);
-
-  glGenBuffers(1, &colorbuffer);
-  glBindBuffer(GL_ARRAY_BUFFER, colorbuffer);
-  // Upload data to VBO
-  glBufferData(GL_ARRAY_BUFFER, sizeof(color_data), color_data, GL_STATIC_DRAW);
-
-  glGenBuffers(1, &uvbuffer);
-  glBindBuffer(GL_ARRAY_BUFFER, uvbuffer);
-  // Upload data to VBO
-  glBufferData(GL_ARRAY_BUFFER, sizeof(uv_data), uv_data, GL_STATIC_DRAW);
-
-  // Initialize PBO *********************************************************
-  glGenBuffers(1, &tex_pbo);
-  glBindBuffer(GL_PIXEL_UNPACK_BUFFER, tex_pbo);
-  glBufferData(GL_PIXEL_UNPACK_BUFFER, 320*240*4, nullptr, GL_STREAM_DRAW);
-
-  // Initialize Texture *****************************************************
-  glGenTextures(1, &screenTex);
-  glBindTexture(GL_TEXTURE_2D, screenTex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 320, 240, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-
-  //glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  //glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-  // Loading shaders ********************************************************
-  auto f_vs = std::fopen("./assets/shaders/mvp_template.vert", "r");
-  if (f_vs != nullptr) {
-    fseek(f_vs, 0L, SEEK_END);
-    size_t bufsize = ftell(f_vs);
-    vertexSource = new GLchar[bufsize + 1]();
-
-    fseek(f_vs, 0L, SEEK_SET);
-    auto t = fread(vertexSource, sizeof(GLchar), bufsize, f_vs);
-    if (t <= 0)
-      std::cerr << "Error reading Vertex Shader\n";
-
-    fclose(f_vs);
-    vertexSource[bufsize] = 0; // Enforce null char
-  }
-
-  //auto f_fs = std::fopen("./assets/shaders/basic_texture.frag", "r");
-  auto f_fs = std::fopen("./assets/shaders/retro_texture.frag", "r");
-  if (f_fs != nullptr) {
-    fseek(f_fs, 0L, SEEK_END);
-    size_t bufsize = ftell(f_fs);
-    fragmentSource = new GLchar[bufsize +1 ]();
-
-    fseek(f_fs, 0L, SEEK_SET);
-    auto t = fread(fragmentSource, sizeof(GLchar), bufsize, f_fs);
-    if (t <= 0)
-      std::cerr << "Error reading Fragment Shader\n";
-
-    fclose(f_fs);
-    fragmentSource[bufsize] = 0; // Enforce null char
-  }
-
-  // Assign our handles a "name" to new shader objects
-  vertexShader = glCreateShader(GL_VERTEX_SHADER);
-  fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
-
-  // Associate the source code buffers with each handle
-  glShaderSource(vertexShader, 1, (const GLchar**)&vertexSource, 0);
-  glShaderSource(fragmentShader, 1, (const GLchar**)&fragmentSource, 0);
-
-  // Compile our shader objects
-  glCompileShader(vertexShader);
-  glCompileShader(fragmentShader);
-
-  if (vertexSource != nullptr)
-    delete[] vertexSource;
-
-  if (fragmentSource != nullptr)
-    delete[] fragmentSource;
-
-
-  GLint Result = GL_FALSE;
-  int InfoLogLength;
-
-  // Vertex Shader compiling error messages
-  glGetShaderiv(vertexShader, GL_COMPILE_STATUS, &Result);
-  glGetShaderiv(vertexShader, GL_INFO_LOG_LENGTH, &InfoLogLength);
-  std::vector<char> VertexShaderErrorMessage(InfoLogLength);
-  glGetShaderInfoLog(vertexShader, InfoLogLength, NULL, &VertexShaderErrorMessage[0]);
-  std::printf("%s\n", &VertexShaderErrorMessage[0]);
-
-  // Fragment Shader compiling error messages
-  glGetShaderiv(fragmentShader, GL_COMPILE_STATUS, &Result);
-  glGetShaderiv(fragmentShader, GL_INFO_LOG_LENGTH, &InfoLogLength);
-  std::vector<char> FragmentShaderErrorMessage(InfoLogLength);
-  glGetShaderInfoLog(fragmentShader, InfoLogLength, NULL, &FragmentShaderErrorMessage[0]);
-  std::printf("%s\n", &FragmentShaderErrorMessage[0]);
-
-
-  // Assign our program handle a "name"
-  shaderProgram = glCreateProgram();
-
-  // Attach our shaders to our program
-  glAttachShader(shaderProgram, vertexShader);
-  glAttachShader(shaderProgram, fragmentShader);
-
-  // Link shader program
-  glLinkProgram(shaderProgram);
-
-
-  // Bind attributes indexes
-  glBindAttribLocation(shaderProgram, sh_in_Position, "in_Position");
-  glBindAttribLocation(shaderProgram, sh_in_Color, "in_Color");
-  glBindAttribLocation(shaderProgram, sh_in_UV, "in_UV");
-
-  modelId = glGetUniformLocation(shaderProgram, "in_Model");
-  viewId  = glGetUniformLocation(shaderProgram, "in_View");
-  projId  = glGetUniformLocation(shaderProgram, "in_Proj");
-
-  timeId = glGetUniformLocation(shaderProgram, "time");
-
-
-  glDeleteShader(vertexShader);
-  glDeleteShader(fragmentShader);
-
-
-  // Camera matrix
-  view = glm::lookAt(
-      glm::vec3(3,3,7), // Camera is at (3,3,7), in World Space
-      glm::vec3(0,0,0), // and looks at the origin
-      glm::vec3(0,1,0)  // Head is up (set to 0,-1,0 to look upside-down)
-      );
-
-}
-
-/*
-void updatePBO (vm::cda::CDA* cda) {
-  using namespace vm;
-
-}
-*/
-
-#endif
 
 


### PR DESCRIPTION
The cleaning and improved main.cpp have a parameter parser with some nice parameters : 

```
Usage:
        ./vm -r romfile [other parameters]

Parameters:
        -r file or --rom file : RAW binary file for the ROM 32 KiB
        -d file or --disk file : Disk file
        -c val or --cpu val : Sets the CPU to use, from "tr3200" or "dcpu-16n"
        -m val or --disk val : How many RAM have the computer in KiB. Must be > 128 and < 1024. Will be round to a multiple of 128
        --clock val : CPU clock speed in Khz. Must be 100, 250, 500 or 1000.
        -b val : Inserts a breakpoint at address val (could be hexadecimal or decimal).
        -h or --help : Shows this help
```

Also, now in "step" mode, can understand a few commands : 
- r : Change to running mode
- q : Quit
- s or enter : Executed an instruction.

Actually only makes optional the few lines of code in TR3200 cpu and VComputer that checks if there is a breakpoint or if has stoped the execution by a breakpoint. Ideally should make optional the definitions of breakpoint methods in VComputer, but I can do that without including Config.hpp in VComputer.hpp what will pollute preprocesor namespace...

Also, main.cpp have a annoying strange bug with break points. It stops/resume very well, switching to step mode, where you can run it in step-by-step and not doing nothing bad. The problem is that after you  halted by a break point,s if you try to switch to run mode again, with 'r', looks that works, but suddenly the screen stops of being updated. I don't know why... any idea ?
