### PR TITLE
Trap interface for CPUs ->Fix Single Step on TR32

### DIFF
--- a/include/cpu.hpp
+++ b/include/cpu.hpp
@@ -69,6 +69,14 @@ public:
     virtual bool SendInterrupt (Word msg) = 0;
 
     /**
+     * Checks if the CPU is generating an trap
+     *
+     * ICPU implementation does nothing.
+     * \param[out] msg The interrupt message will be writen here
+     * \return True if is generating a new interrupt
+     */
+    virtual bool DoesTrap(Word& msg) = 0;
+    /**
      * Writes a copy of CPU state in a chunk of memory pointer by ptr.
      * @param ptr Pointer were to write
      * @param size Size of the chunk of memory were can write. If is

--- a/include/tr3200/tr3200.hpp
+++ b/include/tr3200/tr3200.hpp
@@ -60,6 +60,15 @@ public:
     bool SendInterrupt (Word msg);
 
     /**
+     * Checks if the CPU is generating an trap
+     *
+     * ICPU implementation does nothing.
+     * \param[out] msg The interrupt message will be writen here
+     * \return True if is generating a new interrupt
+     */
+    virtual bool DoesTrap(Word& msg);
+
+    /**
      * Writes a copy of CPU state in a chunk of memory pointer by ptr.
      * @param ptr Pointer were to write
      * @param size Size of the chunk of memory were can write. If is

--- a/src/vcomputer.cpp
+++ b/src/vcomputer.cpp
@@ -247,14 +247,13 @@ unsigned VComputer::Step( const double delta) {
         }
         #endif
 
-        unsigned base_ticks = cpu_ticks * ( BaseClock / cpu->Clock() );
-        unsigned dev_ticks  = (base_ticks / 10); // Devices clock is at
-                                                 // 100 KHz
+        const unsigned base_ticks = cpu_ticks * ( BaseClock / cpu->Clock() );
+        const unsigned dev_ticks  = (base_ticks / 10); // Devices clock is at 100 KHz
         pit.Tick(dev_ticks, delta);
 
+        // Interrupt procesing
         Word msg;
-        bool interrupted = pit.DoesInterrupt(msg); // Highest priority
-                                                   // interrupt
+        bool interrupted = pit.DoesInterrupt(msg); // Highest priority interrupt
         if (interrupted) {
             if ( cpu->SendInterrupt(msg) ) {
                 // Send the interrupt to the CPU
@@ -285,6 +284,11 @@ unsigned VComputer::Step( const double delta) {
             }
         }
 
+        // Process CPU Traps
+        if (!interrupted && cpu->DoesTrap(msg) ) {
+            interrupted = true;
+            cpu->SendInterrupt(msg);
+        }
         return base_ticks;
     }
 


### PR DESCRIPTION
Added a DoesTrap to CPU interface to handle traps in a similar way that
device interrupts. Is procesed after software/devices interrupts.

Interrupts on TR3200 cpu, now are handle only if Interrupt Flag is off
