### PR TITLE
Remove a useless include

### DIFF
--- a/include/device.hpp
+++ b/include/device.hpp
@@ -9,7 +9,6 @@
 #define __IDEVICE_HPP_ 1
 
 #include "types.hpp"
-#include "vcomputer.hpp"
 #include "vc_dll.hpp"
 
 namespace trillek {


### PR DESCRIPTION
This include created a circular include graph which break the compilation in some cases.
