### PR TITLE
Fixed the shader compilation error check condition

### DIFF
--- a/tools/src/gl_engine.cpp
+++ b/tools/src/gl_engine.cpp
@@ -294,7 +294,7 @@ int GlEngine::initGL(OS::OS& os) {
     GLchar* vertexshader_error_msg = new GLchar[InfoLogLength +1];
     glGetShaderInfoLog(vertexShader, InfoLogLength, NULL, vertexshader_error_msg);
     if (vertexshader_error_msg != nullptr) {
-        if (vertexshader_error_msg[0] != '\0') { // Error compiling vertex shader
+        if (Result == GL_FALSE) { // Error compiling vertex shader
             std::fprintf(stderr, "> %s\n", vertexshader_error_msg);
             delete[] vertexshader_error_msg;
             return -1;
@@ -308,7 +308,7 @@ int GlEngine::initGL(OS::OS& os) {
     GLchar* fragmentshader_error_msg = new GLchar[InfoLogLength +1];
     glGetShaderInfoLog(fragmentShader, InfoLogLength, NULL, fragmentshader_error_msg);
     if (fragmentshader_error_msg != nullptr) {
-        if (fragmentshader_error_msg[0] != '\0') { // Error compiling fragment shader
+        if (Result == GL_FALSE) { // Error compiling fragment shader
             std::fprintf(stderr, "> %s\n", fragmentshader_error_msg);
             delete[] fragmentshader_error_msg;
             return -1;


### PR DESCRIPTION
In tools/src/gl_engine.cpp where shaders are compiled, in shader compilation error handling, a check is performed whether the compilation actually failed (lines 297, 311). The condition actually checked is vertexshader_error_msg[0] != '\0'. This makes the emulator think that the compilation failed, while the Result variable is equal to GL_TRUE, which according to the docs (https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glGetShaderiv.xml) means that compilation finished succesfully. InfoLogLength is also equal to 0. I changed the condition being checked according to the documentation. This makes the computer emulator work on my machine.