### PR TITLE
Fix TR3200's SIGXW and SIGXB, align sector data in Media (.dsk) files

### DIFF
--- a/include/devices/media.hpp
+++ b/include/devices/media.hpp
@@ -193,8 +193,17 @@ public:
     }
 
 private:
+    void createMedia(const std::string& filename, DiskDescriptor* info);
+    void writeHeader();
+    int readHeader();
+    void writeBitmap();
+    void readBitmap();
+    void makeOffsets();
+    void upgradeMedia(char to_version);
 
     char HEADER_VERSION;
+    size_t offset_sectors;
+    size_t offset_bitmap;
 
     std::string filename;  /// file name of disk file
     std::fstream datafile; /// disk file on host

--- a/src/devices/media.cpp
+++ b/src/devices/media.cpp
@@ -24,10 +24,10 @@ int32_t CHStoLBA (uint8_t track, uint8_t head, uint8_t sector, const DiskDescrip
     }
 
     // read the sector
-    return (track * descriptor.NumSides + head)* descriptor.SectorsPerTrack + sector -1;
+    return (track * descriptor.NumSides + head) * descriptor.SectorsPerTrack + sector - 1;
 }
 
-Media::Media(const std::string& filename) : HEADER_VERSION(1) {
+Media::Media(const std::string& filename) : HEADER_VERSION(2) {
 
     // Check if file exists
     datafile.open(filename, std::ios::in | std::ios::out | std::ios::binary);
@@ -39,23 +39,77 @@ Media::Media(const std::string& filename) : HEADER_VERSION(1) {
         return;
     }
 
-    char temp[3];
-    datafile.read(temp, 3);
-    if (std::memcmp(temp, HEADER_MAGIC, 3) != 0) {
-#ifndef NDEBUG
-        std::cout << "[DISK] File not a disk image: " << filename.c_str() << std::endl;
-#endif
+    if (!readHeader()) {
         datafile.close();
         return;
     }
+    makeOffsets();
 
-    datafile.read(temp, 1);
-    if (temp[0] != HEADER_VERSION) {
+    readBitmap();
+    if (HEADER_VERSION == 1) upgradeMedia(2);
+
+#ifndef NDEBUG
+    std::cout << "[DISK] File loaded: " << filename.c_str() << std::endl;
+#endif
+}
+
+Media::Media(const std::string& filename, DiskDescriptor* info) : HEADER_VERSION(2) {
+    createMedia(filename, info);
+}
+
+Media::Media(const std::string& filename, const DiskDescriptor& info) : HEADER_VERSION(2) {
+    DiskDescriptor* tmpInfo = new DiskDescriptor();
+    std::memmove(tmpInfo, &info, sizeof(DiskDescriptor));
+    createMedia(filename, tmpInfo);
+}
+
+void Media::createMedia(const std::string& filename, DiskDescriptor* info) {
+    Info.reset(info);
+    // create new file
+#ifndef NDEBUG
+    std::cout << "[DISK] Creating file: " << filename.c_str() << std::endl;
+#endif
+
+    datafile.open(filename, std::ios::in | std::ios::out | std::ios::binary | std::ios::trunc);
+
+    writeHeader();
+    makeOffsets();
+
+    char* sector = new char[Info->BytesPerSector];
+    std::memset(sector, 0, Info->BytesPerSector);
+    datafile.seekg(offset_sectors, std::fstream::beg);
+    for (uint16_t i = 0; i < getTotalSectors(); i++) {
+        datafile.write(sector, Info->BytesPerSector);
+    }
+    delete[] sector;
+
+    writeBitmap();
+
+    datafile.flush();
+}
+
+int Media::readHeader() {
+
+    char temp[4];
+    datafile.seekg(0, std::fstream::beg);
+    datafile.read(temp, 4);
+    if (std::memcmp(temp, HEADER_MAGIC, 3) != 0) {
+#ifndef NDEBUG
+        std::cout << "[DISK] File not a valid disk image: " << filename.c_str() << std::endl;
+#endif
+        return 0;
+    }
+
+    switch (temp[3]) {
+    case 1:
+    case 2:
+        HEADER_VERSION = temp[3];
+        break;
+    default:
 #ifndef NDEBUG
         std::cout << "[DISK] File is wrong version: " << filename.c_str() << std::endl;
 #endif
-        datafile.close();
-        return;
+        return 0;
     }
 
     Info.reset(new DiskDescriptor);
@@ -68,30 +122,11 @@ Media::Media(const std::string& filename) : HEADER_VERSION(1) {
     datafile.read(reinterpret_cast<char*>(&Info->SectorsPerTrack), 1);
     datafile.read(reinterpret_cast<char*>(&Info->BytesPerSector), 2);
 
-    /* Get bad sector bitmap from the file */
-    int bitmapSize = getTotalSectors() / 8;
-    bitmapSize += getTotalSectors() % 8 != 0 ? 1 : 0;
-    badSectors  = std::vector<uint8_t>(bitmapSize);
-
-    datafile.seekg(HEADER_SIZE + getTotalSectors() * Info->BytesPerSector, std::fstream::beg);
-    datafile.read( reinterpret_cast<char*>( badSectors.data() ), badSectors.size() );
-
-#ifndef NDEBUG
-    std::cout << "[DISK] File loaded: " << filename.c_str() << std::endl;
-#endif
+    return 1;
 }
 
-Media::Media(const std::string& filename, DiskDescriptor* info)  : HEADER_VERSION(1) {
-
-    Info.reset(info);
-
-    // create new file
-#ifndef NDEBUG
-    std::cout << "[DISK] Creating file: " << filename.c_str() << std::endl;
-#endif
-
-    datafile.open(filename, std::ios::in | std::ios::out | std::ios::binary | std::ios::trunc);
-
+void Media::writeHeader() {
+    datafile.seekg(0, std::fstream::beg);
     /* write file header */
     datafile.write(HEADER_MAGIC, 3);
     datafile.write(&HEADER_VERSION, 1);
@@ -101,67 +136,33 @@ Media::Media(const std::string& filename, DiskDescriptor* info)  : HEADER_VERSIO
     datafile.write(reinterpret_cast<char*>(&Info->TracksPerSide), 1);
     datafile.write(reinterpret_cast<char*>(&Info->SectorsPerTrack), 1);
     datafile.write(reinterpret_cast<char*>(&Info->BytesPerSector), 2);
-
-    char* sector = new char[Info->BytesPerSector];
-    std::memset(sector, 0, Info->BytesPerSector);
-    datafile.seekg(HEADER_SIZE, std::fstream::beg);
-    for (uint16_t i = 0; i < getTotalSectors(); i++) {
-        datafile.write(sector, Info->BytesPerSector);
-    }
-    delete[] sector;
-
-    /* Get bad sector bitmap from the file */
-    int bitmapSize = getTotalSectors() / 8;
-    bitmapSize += getTotalSectors() % 8 != 0 ? 1 : 0;
-    badSectors  = std::vector<uint8_t>(bitmapSize);
-    badSectors.assign(badSectors.size(), 0);
-
-    datafile.seekg(HEADER_SIZE + getTotalSectors() * Info->BytesPerSector, std::fstream::beg);
-    datafile.write( reinterpret_cast<char*>( badSectors.data() ), badSectors.size() );
-
-    datafile.flush();
 }
 
-Media::Media(const std::string& filename, const DiskDescriptor& info)  : HEADER_VERSION(1) {
-    DiskDescriptor* tmpInfo = new DiskDescriptor();
-    std::memmove(tmpInfo, &info, sizeof(DiskDescriptor));
-    Info.reset(tmpInfo);
-
-    // create new file
-#ifndef NDEBUG
-    std::cout << "[DISK] Creating file: " << filename.c_str() << std::endl;
-#endif
-
-    datafile.open(filename, std::ios::in | std::ios::out | std::ios::binary | std::ios::trunc);
-
-    /* write file header */
-    datafile.write(HEADER_MAGIC, 3);
-    datafile.write(&HEADER_VERSION, 1);
-    datafile.write(reinterpret_cast<char*>(&Info->TypeDisk), 1);
-    datafile.write(reinterpret_cast<char*>(&Info->writeProtect), 1);
-    datafile.write(reinterpret_cast<char*>(&Info->NumSides), 1);
-    datafile.write(reinterpret_cast<char*>(&Info->TracksPerSide), 1);
-    datafile.write(reinterpret_cast<char*>(&Info->SectorsPerTrack), 1);
-    datafile.write(reinterpret_cast<char*>(&Info->BytesPerSector), 2);
-
-    char* sector = new char[Info->BytesPerSector];
-    std::memset(sector, 0, Info->BytesPerSector);
-    datafile.seekg(HEADER_SIZE, std::fstream::beg);
-    for (uint16_t i = 0; i < getTotalSectors(); i++) {
-        datafile.write(sector, Info->BytesPerSector);
+void Media::makeOffsets() {
+    /* calculate the base offsets for data */
+    switch (HEADER_VERSION) {
+    case 1:
+        offset_sectors = HEADER_SIZE;
+        offset_bitmap = offset_sectors + getTotalSectors() * Info->BytesPerSector;
+        break;
+    default:
+    case 2:
+        offset_sectors = 0x20;
+        offset_bitmap = offset_sectors + getTotalSectors() * Info->BytesPerSector;
+        break;
     }
-    delete[] sector;
 
-    /* Get bad sector bitmap from the file */
     int bitmapSize = getTotalSectors() / 8;
     bitmapSize += getTotalSectors() % 8 != 0 ? 1 : 0;
-    badSectors  = std::vector<uint8_t>(bitmapSize);
-    badSectors.assign(badSectors.size(), 0);
+    const uint8_t fill = 0;
+    if (badSectors.size() != bitmapSize) {
+        badSectors = std::vector<uint8_t>(bitmapSize, fill);
+    }
 
-    datafile.seekg(HEADER_SIZE + getTotalSectors() * Info->BytesPerSector, std::fstream::beg);
-    datafile.write( reinterpret_cast<char*>( badSectors.data() ), badSectors.size() );
+#ifndef NDEBUG
+    std::fprintf(stderr, "[DISK] bitmap at 0x%04zX, size 0x%04zX\n", offset_bitmap, bitmapSize);
+#endif
 
-    datafile.flush();
 }
 
 Media::~Media() {
@@ -174,8 +175,64 @@ Media::~Media() {
     }
 }
 
+/* Write the bad-sector bitmap to the file */
+void Media::writeBitmap() {
+    datafile.seekg(offset_bitmap, std::fstream::beg);
+    datafile.write( reinterpret_cast<char*>( badSectors.data() ), badSectors.size() );
+}
+
+/* Get bad sector bitmap from the file */
+void Media::readBitmap() {
+    datafile.seekg(offset_bitmap, std::fstream::beg);
+    datafile.read( reinterpret_cast<char*>( badSectors.data() ), badSectors.size() );
+}
+
+/* convert from one version of media to another */
+void Media::upgradeMedia(char to_version) {
+    size_t offset_sectors_old = offset_sectors;
+    if (to_version == HEADER_VERSION) return;
+#ifndef NDEBUG
+    std::cout << "[DISK] Upgrade file version from " << (int)HEADER_VERSION << " to " << (int)to_version << std::endl;
+#endif
+    HEADER_VERSION = to_version;
+    makeOffsets();
+    if (offset_sectors > offset_sectors_old) {
+        /* move sector data up by starting at the end and going down */
+        char* sector = new char[Info->BytesPerSector];
+        std::memset(sector, 0, Info->BytesPerSector);
+        for (size_t i = getTotalSectors(); i-- > 0;) {
+            size_t offset = i * Info->BytesPerSector;
+            datafile.seekg(offset_sectors_old + offset, std::fstream::beg);
+            datafile.read(sector, Info->BytesPerSector);
+            datafile.seekg(offset_sectors + offset, std::fstream::beg);
+            datafile.write(sector, Info->BytesPerSector);
+        }
+        delete[] sector;
+    }
+    else if (offset_sectors < offset_sectors_old) {
+        /* move sector data down by starting at the beginning and going up */
+        char* sector = new char[Info->BytesPerSector];
+        std::memset(sector, 0, Info->BytesPerSector);
+        for (size_t i = 0; i < getTotalSectors(); i++) {
+            size_t offset = i * Info->BytesPerSector;
+            datafile.seekg(offset_sectors_old + offset, std::fstream::beg);
+            datafile.read(sector, Info->BytesPerSector);
+            datafile.seekg(offset_sectors + offset, std::fstream::beg);
+            datafile.write(sector, Info->BytesPerSector);
+        }
+        delete[] sector;
+    }
+    writeHeader();
+    writeBitmap();
+
+    datafile.flush();
+}
+
 uint8_t Media::getBytesExponent() const {
-    return log2(Info->BytesPerSector);
+    int e = 0;
+    uint32_t test = 1;
+    for (; test < Info->BytesPerSector; test <<= 1, e++);
+    return e;
 }
 
 
@@ -184,7 +241,7 @@ bool Media::isSectorBad(uint16_t sector) const {
         return true;
     }
 
-    return badSectors[sector / 8] & 128 >> (sector % 8);
+    return badSectors[sector / 8] & (0x80 >> (sector % 8));
 }
 
 ERRORS Media::setSectorBad(uint16_t sector, bool state) {
@@ -202,13 +259,13 @@ ERRORS Media::setSectorBad(uint16_t sector, bool state) {
     unsigned opt_sector_8 = sector / 8;
 
     if (state) {
-        badSectors[opt_sector_8] |= 128 >> (sector % 8);
+        badSectors[opt_sector_8] |= 0x80 >> (sector % 8);
     }
     else {
-        badSectors[opt_sector_8] &= ~( 128 >> (sector % 8) );
+        badSectors[opt_sector_8] &= ~( 0x80 >> (sector % 8) );
     }
 
-    datafile.seekg(HEADER_SIZE + getTotalSectors() * Info->BytesPerSector + opt_sector_8, std::ios::beg);
+    datafile.seekg(offset_bitmap + opt_sector_8, std::ios::beg);
     datafile.write(reinterpret_cast<char*>( &(badSectors[opt_sector_8]) ), 1);
 
     return ERRORS::NONE;
@@ -221,11 +278,12 @@ ERRORS Media::readSector(uint16_t sector, std::vector<uint8_t>* data) {
     if ( sector >= getTotalSectors() || isSectorBad(sector) ) {
         return ERRORS::BAD_SECTOR;
     }
+    size_t which_sector = offset_sectors + sector * Info->BytesPerSector;
 #ifndef NDEBUG
-        std::fprintf(stderr, "[DISK] Read at 0x%04X\n",(HEADER_SIZE + sector * Info->BytesPerSector) );
+        std::fprintf(stderr, "[DISK] Read at 0x%04zX\n", which_sector);
 #endif
 
-    datafile.seekg(HEADER_SIZE + sector * Info->BytesPerSector, std::ios::beg);
+    datafile.seekg(which_sector, std::ios::beg);
     datafile.read( reinterpret_cast<char*>( data->data() ), data->size() );
 
     return ERRORS::NONE;
@@ -241,12 +299,13 @@ ERRORS Media::writeSector(uint16_t sector, std::vector<uint8_t>* data, bool dryR
     if (Info->writeProtect) {
         return ERRORS::PROTECTED;
     }
+    size_t which_sector = offset_sectors + sector * Info->BytesPerSector;
 
     if (!dryRun) {
 #ifndef NDEBUG
-        std::fprintf(stderr, "[DISK] Write at 0x%04X\n",(HEADER_SIZE + sector * Info->BytesPerSector) );
+        std::fprintf(stderr, "[DISK] Write at 0x%04zX\n", which_sector);
 #endif
-        datafile.seekg(HEADER_SIZE + sector * Info->BytesPerSector, std::ios::beg);
+        datafile.seekg(which_sector, std::ios::beg);
         datafile.write( reinterpret_cast<const char*>( data->data() ), data->size() );
         datafile.flush();
     }
@@ -264,12 +323,13 @@ ERRORS Media::writeSector(uint16_t sector, const uint8_t* data, size_t data_size
     if (Info->writeProtect) {
         return ERRORS::PROTECTED;
     }
+    size_t which_sector = offset_sectors + sector * Info->BytesPerSector;
 #ifndef NDEBUG
-        std::fprintf(stderr, "[DISK] Write at 0x%04X\n",(HEADER_SIZE + sector * Info->BytesPerSector) );
+        std::fprintf(stderr, "[DISK] Write at 0x%04zX\n", which_sector);
 #endif
 
     if (!dryRun) {
-        datafile.seekg(HEADER_SIZE + sector * Info->BytesPerSector, std::ios::beg);
+        datafile.seekg(which_sector, std::ios::beg);
         datafile.write( reinterpret_cast<const char*>( data ), data_size );
         datafile.flush();
     }

--- a/src/tr3200/tr3200.cpp
+++ b/src/tr3200/tr3200.cpp
@@ -487,19 +487,19 @@ unsigned TR3200::RealStep() {
 
             case P2_OPCODE::SIGXB:
                 if ( (rn & 0x00000080) != 0 ) {
-                    rd |= 0xFFFFFF00; // Negative
+                    r[rd] = rn | 0xFFFFFF00; // Negative
                 }
                 else {
-                    rd &= 0x000000FF; // Positive
+                    r[rd] = rn & 0x000000FF; // Positive
                 }
                 break;
 
             case P2_OPCODE::SIGXW:
                 if ( (rn & 0x00008000) != 0 ) {
-                    rd |= 0xFFFF0000; // Negative
+                    r[rd] = rn | 0xFFFF0000; // Negative
                 }
                 else {
-                    rd &= 0x0000FFFF; // Positive
+                    r[rd] = rn & 0x0000FFFF; // Positive
                 }
                 break;
 

--- a/tools/include/os.hpp
+++ b/tools/include/os.hpp
@@ -20,6 +20,7 @@
 #include "keyboard_input_system.hpp"
 
 #include <cstdio>
+#include <string>
 #include <iostream>
 
 namespace OS {


### PR DESCRIPTION
- `SIGXW` and `SIGXB` didn't work because they were modifying an internal variable, not the registers, fixed!
- Added some utility functions to the Media class, so large amounts of code aren't duplicated.
Since the Media header is 11 bytes long, I added a "version 2" of the file format where the sector data is 32 byte aligned.
- Added a function to Media class to convert files between version 1 and 2.
It automatically converts version 1 to version 2 when it opens a file.
This seems unlikely to cause any problems.